### PR TITLE
Add Apps Script deployment workflow

### DIFF
--- a/.clasp.json
+++ b/.clasp.json
@@ -1,0 +1,4 @@
+{
+  "scriptId": "YOUR_APPS_SCRIPT_ID",
+  "rootDir": "."
+}

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -1,0 +1,50 @@
+name: Deploy Apps Script
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Push Apps Script
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        if: ${{ hashFiles('package-lock.json') != '' }}
+        run: npm ci
+
+      - name: Run lint (optional)
+        if: ${{ env.SKIP_LINT != 'true' }}
+        run: |
+          if npm run | grep -q " lint"; then
+            npm run lint
+          else
+            echo "No lint script detected; skipping."
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Install clasp
+        run: npm install -g @google/clasp
+
+      - name: Push to Apps Script
+        run: clasp push --force

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# ReLead-EDU Deployment Notes
+
+## Apps Script Deployment
+
+This repository is configured to deploy the `apps-script.gs` file to Google Apps Script when changes are pushed to the `main` branch.
+
+### Required configuration
+
+- **Apps Script `scriptId`**: Update [`.clasp.json`](.clasp.json) with the script identifier of the target Apps Script project before running any deployments.
+- **`GCP_SA_KEY` secret**: Upload the JSON key for a Google Cloud service account with Editor access to the target Apps Script project as the `GCP_SA_KEY` repository secret.
+- **`CLASP_IGNORE` (optional)**: Define this environment variable if you need to override the default `.claspignore` behaviour during automated deployments.
+- **Branch protection**: Protect the `main` branch to ensure that linting and review requirements are satisfied before code is merged and deployment is triggered.
+
+### GitHub Actions workflow
+
+The workflow defined at [`.github/workflows/deploy-apps-script.yml`](.github/workflows/deploy-apps-script.yml) performs the following steps:
+
+1. Checks out the repository and installs Node.js dependencies (when a lockfile is present).
+2. Optionally runs `npm run lint`, blocking the deployment if lint errors are reported and the script is defined.
+3. Authenticates to Google Cloud using `google-github-actions/auth@v1` with the `GCP_SA_KEY` secret and sets up the Cloud SDK via `google-github-actions/setup-gcloud@v1`.
+4. Installs the Apps Script CLI (`@google/clasp`) globally and force pushes the local source to Apps Script using `clasp push --force`.
+
+### Manual steps
+
+Some configuration cannot be automated from this repository:
+
+- Creating the Google Cloud service account and downloading its JSON credentials must be done manually in the Google Cloud Console.
+- Upload the downloaded JSON as the `GCP_SA_KEY` secret in the GitHub repository settings.
+- Configure the required branch protections directly in the repository settings.


### PR DESCRIPTION
## Summary
- add `.clasp.json` to configure the Apps Script project
- document required configuration, secrets, and branch protections for the deployment workflow
- create a GitHub Actions workflow that authenticates with Google Cloud, optionally runs linting, installs clasp, and pushes to Apps Script on main merges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cca0cdfd20832c9473e8fafbaf7f8f