### PR TITLE
feat: hero y casos de éxito en landing

### DIFF
--- a/docs/diseno/landing.md
+++ b/docs/diseno/landing.md
@@ -1,0 +1,49 @@
+# Landing ReLead EDU
+
+## Wireframes propuestos
+
+### Sección hero
+- **Estructura**: layout en dos columnas; izquierda contenido textual y métricas en carrusel; derecha tarjeta de acceso (login).
+- **Jerarquía**:
+  1. Kicker con ícono para reforzar categoría.
+  2. Titular principal (máximo 2 líneas) con tipografía Manrope 800.
+  3. Subtítulo con énfasis en beneficio medible.
+  4. Grupo de CTAs primario/secundario.
+  5. Carrusel horizontal de métricas repetidas para continuidad.
+- **Comportamiento**: carrusel automático con pausa al reducir movimientos (`prefers-reduced-motion`).
+
+### Sección “Casos de éxito”
+- **Layout**: bloque full-width con fondo suave (gradiente) y cards individuales.
+- **Cards**: emplean variables `--radius` y `--shadow`, contenido con cita + autor + rol.
+- **Contenido**: mínimo 3 testimonios simultáneos.
+
+## Copy sugerido
+
+### Hero
+- **Kicker**: "Plataforma de reactivación".
+- **Titular**: "Impulsa la retención con decisiones basadas en datos".
+- **Subtítulo**: "ReLead EDU centraliza seguimiento, priorización y comunicación para que cada plantel recupere leads dormidos en menos tiempo.".
+- **CTA primario**: "Solicitar demo guiada" → `mailto:hola@relead.edu?subject=Quiero%20una%20demo`.
+- **CTA secundario**: "Contactar a ventas" → `mailto:ventas@relead.edu`.
+- **Métricas**:
+  - `+62%` leads reactivados (promedio 90 días).
+  - `-38%` tiempo de respuesta (SLA de atención).
+  - `x1.8` productividad de asesores (leads por jornada).
+  - `12` integraciones activas (CRM y sistemas escolares).
+
+### Casos de éxito
+- **Título**: "Casos de éxito".
+- **Descripción**: "Instituciones que combinan datos, automatización y seguimiento omnicanal con ReLead EDU para sostener su matrícula.".
+- **Testimonios**:
+  1. Universidad Horizonte — Dirección de Admisiones.
+  2. Red Instituto Valle — Coordinación Comercial.
+  3. Colegio Delta — Gerencia de Experiencia.
+
+## Especificaciones responsive
+
+| Breakpoint | Layout | Notas |
+|------------|--------|-------|
+| ≥1200px    | Hero en dos columnas con carrusel ocupando 60% del ancho disponible; tarjeta de login fija a la derecha; bloque de casos de éxito con 3 columnas. | Altura mínima 90vh; CTAs en fila. |
+| 768px–1199px | Hero cambia a una columna, login debajo; carrusel conserva scroll automático y ancho completo; casos de éxito en 2 columnas. | CTAs se vuelven botones expandibles (flex-wrap). |
+| ≤767px     | Pila vertical: kicker, título, subtítulo, CTAs, carrusel; tarjeta de login ocupa 100%; casos de éxito en 1 columna con padding reducido. | Carrusel permite scroll táctil y se desactiva animación si hay `prefers-reduced-motion`. |
+

--- a/index.html
+++ b/index.html
@@ -173,11 +173,232 @@
       inset:0;
       z-index:100;
       display:flex;
-      align-items:center;
+      flex-direction:column;
+      gap:calc(var(--space) * 1.5);
+      align-items:stretch;
       justify-content:center;
-      padding:var(--space);
+      padding:calc(var(--space) * 2) clamp(var(--space), 5vw, calc(var(--space) * 4));
+      overflow-y:auto;
       background: radial-gradient(1200px 600px at 80% -10%, rgba(138,156,163,0.22), transparent 60%), radial-gradient(900px 500px at -10% 10%, rgba(0,58,95,0.25), transparent 60%), rgba(11,18,32,0.92);
       backdrop-filter: blur(8px);
+    }
+    .landing-layout{
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+      gap:calc(var(--space) * 2);
+      align-items:center;
+    }
+    .landing-hero{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space);
+      color:var(--panel-stage-text);
+    }
+    .hero-kicker{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      width:max-content;
+      padding:6px 12px;
+      font-size:12px;
+      font-weight:700;
+      letter-spacing:.4px;
+      text-transform:uppercase;
+      border-radius:999px;
+      background:rgba(var(--panel-base-rgb),0.18);
+      color:var(--panel-stage-text);
+      box-shadow:inset 0 1px 0 rgba(255,255,255,0.18);
+    }
+    .landing-hero h1{
+      margin:0;
+      font-size:clamp(32px, 5vw, 48px);
+      line-height:1.1;
+      font-weight:800;
+    }
+    .hero-subtitle{
+      margin:0;
+      font-size:clamp(16px, 2.2vw, 20px);
+      color:color-mix(in srgb, var(--panel-stage-text) 82%, rgba(255,255,255,0.32) 18%);
+      max-width:46ch;
+    }
+    html[data-theme="light"] .hero-subtitle{
+      color:color-mix(in srgb, #0f172a 78%, rgba(15,23,42,0.32) 22%);
+    }
+    .hero-cta{
+      display:flex;
+      flex-wrap:wrap;
+      gap:var(--space-sm);
+      align-items:center;
+    }
+    .hero-cta .btn{
+      min-width:180px;
+      justify-content:center;
+      font-weight:700;
+    }
+    .btn.outline{
+      background:transparent;
+      border:1px solid rgba(255,255,255,0.5);
+      color:var(--panel-stage-text);
+    }
+    .btn.outline:hover,
+    .btn.outline:focus-visible{
+      background:rgba(var(--panel-base-rgb),0.12);
+      color:var(--panel-stage-text);
+    }
+    html[data-theme="light"] .btn.outline{
+      border-color:rgba(15,23,42,0.16);
+      color:var(--text);
+    }
+    html[data-theme="light"] .btn.outline:hover,
+    html[data-theme="light"] .btn.outline:focus-visible{
+      background:rgba(var(--panel-base-rgb),0.12);
+    }
+    .hero-metrics{
+      position:relative;
+      overflow:hidden;
+      margin-top:var(--space);
+    }
+    .hero-metrics__viewport{
+      overflow:hidden;
+      mask-image:linear-gradient(90deg, transparent 0%, rgba(0,0,0,0.85) 12%, rgba(0,0,0,0.85) 88%, transparent 100%);
+    }
+    .hero-metrics__track{
+      display:flex;
+      gap:var(--space);
+      width:max-content;
+      animation:heroCarousel 32s linear infinite;
+    }
+    .hero-metric{
+      display:flex;
+      flex-direction:column;
+      justify-content:center;
+      gap:6px;
+      min-width:200px;
+      padding:18px 20px;
+      border-radius:calc(var(--radius) - 4px);
+      border:1px solid rgba(255,255,255,0.14);
+      background:linear-gradient(135deg, rgba(var(--panel-base-rgb),0.28), rgba(11,18,32,0.6));
+      box-shadow:0 18px 40px rgba(2,10,28,0.45);
+      color:var(--panel-stage-text);
+    }
+    html[data-theme="light"] .hero-metric{
+      border-color:rgba(15,23,42,0.08);
+      background:linear-gradient(135deg, rgba(var(--panel-base-rgb),0.14), #fff);
+      color:#0f172a;
+      box-shadow:0 18px 42px rgba(var(--panel-base-rgb),0.24);
+    }
+    .hero-metric__value{
+      font-size:26px;
+      font-weight:800;
+      letter-spacing:-0.5px;
+    }
+    .hero-metric__label{
+      font-size:13px;
+      letter-spacing:.2px;
+      text-transform:uppercase;
+      color:color-mix(in srgb, currentColor 72%, rgba(255,255,255,0.45) 28%);
+    }
+    .hero-metric__trend{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      font-size:13px;
+      font-weight:600;
+      color:var(--ok);
+    }
+    html[data-theme="light"] .hero-metric__label{
+      color:color-mix(in srgb, currentColor 70%, rgba(15,23,42,0.3) 30%);
+    }
+    .hero-metric__trend .bi{ font-size:16px; }
+    @keyframes heroCarousel{
+      0%{ transform:translateX(0); }
+      100%{ transform:translateX(-50%); }
+    }
+    @media (prefers-reduced-motion: reduce){
+      .hero-metrics__track{ animation:none; }
+    }
+    .success-stories{
+      display:flex;
+      flex-direction:column;
+      gap:calc(var(--space) * 1.5);
+      padding:calc(var(--space) * 1.5) clamp(var(--space), 6vw, calc(var(--space) * 4));
+      border-radius:calc(var(--radius) * 1.25);
+      background:rgba(15,23,42,0.32);
+      border:1px solid rgba(255,255,255,0.12);
+      box-shadow:0 28px 60px rgba(2,10,28,0.35);
+      color:var(--panel-stage-text);
+    }
+    html[data-theme="light"] .success-stories{
+      background:linear-gradient(135deg, rgba(var(--panel-base-rgb),0.12), #ffffff);
+      border-color:rgba(15,23,42,0.08);
+      box-shadow:0 32px 72px rgba(var(--panel-base-rgb),0.18);
+      color:#0f172a;
+    }
+    .success-header h2{
+      margin:0 0 6px;
+      font-size:clamp(26px, 3vw, 32px);
+      font-weight:800;
+    }
+    .success-header p{
+      margin:0;
+      max-width:60ch;
+      color:color-mix(in srgb, currentColor 78%, rgba(255,255,255,0.32) 22%);
+    }
+    html[data-theme="light"] .success-header p{
+      color:color-mix(in srgb, currentColor 68%, rgba(15,23,42,0.32) 32%);
+    }
+    .success-grid{
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+      gap:var(--space);
+    }
+    .success-card{
+      display:flex;
+      flex-direction:column;
+      gap:var(--space-sm);
+      padding:var(--space);
+      border-radius:var(--radius);
+      background:var(--card);
+      border:1px solid rgba(255,255,255,0.12);
+      box-shadow:var(--shadow);
+    }
+    html[data-theme="light"] .success-card{
+      border-color:rgba(15,23,42,0.08);
+    }
+    .success-card__meta{
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+    }
+    .success-card__quote{
+      margin:0;
+      font-size:15px;
+      line-height:1.55;
+      color:color-mix(in srgb, currentColor 80%, rgba(255,255,255,0.26) 20%);
+    }
+    html[data-theme="light"] .success-card__quote{
+      color:color-mix(in srgb, currentColor 80%, rgba(15,23,42,0.18) 20%);
+    }
+    .success-card__author{
+      font-weight:700;
+      color:var(--panel-base-bright);
+    }
+    html[data-theme="light"] .success-card__author{
+      color:color-mix(in srgb, rgb(var(--panel-base-rgb)) 60%, #0f172a 40%);
+    }
+    .success-card__role{
+      margin:0;
+      font-size:13px;
+      color:var(--muted);
+    }
+    @media (max-width: 900px){
+      .landing-layout{ grid-template-columns:1fr; }
+      .hero-cta .btn{ flex:1 1 140px; }
+    }
+    @media (max-width: 600px){
+      .success-stories{
+        padding:calc(var(--space) * 1.25);
+      }
     }
     .login-card{
       width:min(100%, 360px);
@@ -1356,53 +1577,139 @@
 </head>
 <body>
   <div class="login-screen" id="loginScreen" aria-hidden="false">
-    <div class="login-card" role="dialog" aria-labelledby="loginTitle">
-      <div class="login-logo" aria-hidden="true">
-        <img src="./icon-unidep180.png" alt="" width="132" height="132" />
-      </div>
-      <h1 id="loginTitle" class="login-title">ReLead EDU</h1>
-      <p class="login-intro">Bienvenido. Si es tu primer acceso, utiliza el correo e ID que te compartió la coordinación para generar tu contraseña y empezar a atender leads de inmediato.</p>
-      <div id="loginSignIn" aria-hidden="false">
-        <form class="login-form" id="loginForm" autocomplete="off">
-          <label>
-            <span>Correo institucional</span>
-            <input type="email" id="loginEmail" autocomplete="username" required />
-          </label>
-          <label>
-            <span>Contraseña</span>
-            <input type="password" id="loginPassword" autocomplete="current-password" required />
-          </label>
-          <div class="login-actions">
-            <button type="submit" class="btn primary w100" id="loginSubmit">Entrar a mi tablero</button>
+    <div class="landing-layout">
+      <section class="landing-hero" aria-labelledby="heroTitle">
+        <span class="hero-kicker"><i class="bi bi-stars" aria-hidden="true"></i> Plataforma de reactivación</span>
+        <h1 id="heroTitle">Impulsa la retención con decisiones basadas en datos</h1>
+        <p class="hero-subtitle">ReLead EDU centraliza seguimiento, priorización y comunicación para que cada plantel recupere leads dormidos en menos tiempo.</p>
+        <div class="hero-cta">
+          <a class="btn primary" href="mailto:hola@relead.edu?subject=Quiero%20una%20demo" data-cta="demo">Solicitar demo guiada</a>
+          <a class="btn outline" href="mailto:ventas@relead.edu" data-cta="contacto">Contactar a ventas</a>
+        </div>
+        <div class="hero-metrics" aria-label="Resultados destacados">
+          <div class="hero-metrics__viewport" role="list">
+            <div class="hero-metrics__track">
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Leads reactivados</span>
+                <span class="hero-metric__value">+62%</span>
+                <span class="hero-metric__trend"><i class="bi bi-arrow-up-right"></i> Promedio 90 días</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Tiempo de respuesta</span>
+                <span class="hero-metric__value">-38%</span>
+                <span class="hero-metric__trend"><i class="bi bi-lightning-charge"></i> SLA de atención</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Productividad de asesores</span>
+                <span class="hero-metric__value">x1.8</span>
+                <span class="hero-metric__trend"><i class="bi bi-people"></i> Leads por jornada</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Integraciones activas</span>
+                <span class="hero-metric__value">12</span>
+                <span class="hero-metric__trend"><i class="bi bi-plug"></i> CRM y sistemas escolares</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Leads reactivados</span>
+                <span class="hero-metric__value">+62%</span>
+                <span class="hero-metric__trend"><i class="bi bi-arrow-up-right"></i> Promedio 90 días</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Tiempo de respuesta</span>
+                <span class="hero-metric__value">-38%</span>
+                <span class="hero-metric__trend"><i class="bi bi-lightning-charge"></i> SLA de atención</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Productividad de asesores</span>
+                <span class="hero-metric__value">x1.8</span>
+                <span class="hero-metric__trend"><i class="bi bi-people"></i> Leads por jornada</span>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <span class="hero-metric__label">Integraciones activas</span>
+                <span class="hero-metric__value">12</span>
+                <span class="hero-metric__trend"><i class="bi bi-plug"></i> CRM y sistemas escolares</span>
+              </article>
+            </div>
           </div>
-        </form>
-        <p class="login-message login-error hidden" id="loginError" role="alert"></p>
-        <p class="login-hint" id="loginHint">¿Es tu primer ingreso o olvidaste tu contraseña? <button type="button" class="link-button" id="forgotPasswordBtn">Solicita una contraseña temporal</button>.</p>
+        </div>
+      </section>
+      <div class="login-card" role="dialog" aria-labelledby="loginTitle">
+        <div class="login-logo" aria-hidden="true">
+          <img src="./icon-unidep180.png" alt="" width="132" height="132" />
+        </div>
+        <h1 id="loginTitle" class="login-title">ReLead EDU</h1>
+        <p class="login-intro">Bienvenido. Si es tu primer acceso, utiliza el correo e ID que te compartió la coordinación para generar tu contraseña y empezar a atender leads de inmediato.</p>
+        <div id="loginSignIn" aria-hidden="false">
+          <form class="login-form" id="loginForm" autocomplete="off">
+            <label>
+              <span>Correo institucional</span>
+              <input type="email" id="loginEmail" autocomplete="username" required />
+            </label>
+            <label>
+              <span>Contraseña</span>
+              <input type="password" id="loginPassword" autocomplete="current-password" required />
+            </label>
+            <div class="login-actions">
+              <button type="submit" class="btn primary w100" id="loginSubmit">Entrar a mi tablero</button>
+            </div>
+          </form>
+          <p class="login-message login-error hidden" id="loginError" role="alert"></p>
+          <p class="login-hint" id="loginHint">¿Es tu primer ingreso o olvidaste tu contraseña? <button type="button" class="link-button" id="forgotPasswordBtn">Solicita una contraseña temporal</button>.</p>
+        </div>
+        <div id="loginReset" class="hidden" aria-hidden="true">
+          <form class="login-form" id="resetForm" autocomplete="off">
+            <p class="login-hint">Ingresa el correo institucional y tu ID de usuario tal como aparecen en tu hoja de asignación para generar una contraseña temporal de acceso inicial.</p>
+            <label>
+              <span>Correo institucional</span>
+              <input type="email" id="resetEmail" autocomplete="username" required />
+            </label>
+            <label>
+              <span>ID de usuario</span>
+              <input type="text" id="resetUserId" autocomplete="off" required />
+            </label>
+            <div class="login-actions">
+              <button type="submit" class="btn primary w100" id="resetSubmit">Crear contraseña temporal</button>
+              <button type="button" class="btn w100" id="resetCancel">Volver a iniciar sesión</button>
+            </div>
+          </form>
+          <p class="login-message login-info hidden" id="resetMessage" role="status" aria-live="polite"></p>
+          <p class="login-hint" id="resetHint">La contraseña temporal se muestra una sola vez. Anótala y cámbiala desde Configuración &gt; Seguridad después de entrar.</p>
+        </div>
+        <footer class="login-meta">
+          <span class="login-meta__version" data-version-format="Versión {version}"></span>
+          <span class="login-meta__rights">ReLead<sup>©</sup> Todos los Derechos Reservados</span>
+        </footer>
       </div>
-      <div id="loginReset" class="hidden" aria-hidden="true">
-        <form class="login-form" id="resetForm" autocomplete="off">
-          <p class="login-hint">Ingresa el correo institucional y tu ID de usuario tal como aparecen en tu hoja de asignación para generar una contraseña temporal de acceso inicial.</p>
-          <label>
-            <span>Correo institucional</span>
-            <input type="email" id="resetEmail" autocomplete="username" required />
-          </label>
-          <label>
-            <span>ID de usuario</span>
-            <input type="text" id="resetUserId" autocomplete="off" required />
-          </label>
-          <div class="login-actions">
-            <button type="submit" class="btn primary w100" id="resetSubmit">Crear contraseña temporal</button>
-            <button type="button" class="btn w100" id="resetCancel">Volver a iniciar sesión</button>
-          </div>
-        </form>
-        <p class="login-message login-info hidden" id="resetMessage" role="status" aria-live="polite"></p>
-        <p class="login-hint" id="resetHint">La contraseña temporal se muestra una sola vez. Anótala y cámbiala desde Configuración &gt; Seguridad después de entrar.</p>
-      </div>
-      <footer class="login-meta">
-        <span class="login-meta__version" data-version-format="Versión {version}"></span>
-        <span class="login-meta__rights">ReLead<sup>©</sup> Todos los Derechos Reservados</span>
-      </footer>
     </div>
+    <section class="success-stories" aria-labelledby="successTitle">
+      <header class="success-header">
+        <h2 id="successTitle">Casos de éxito</h2>
+        <p>Instituciones que combinan datos, automatización y seguimiento omnicanal con ReLead EDU para sostener su matrícula.</p>
+      </header>
+      <div class="success-grid" role="list">
+        <article class="success-card" role="listitem">
+          <p class="success-card__quote">“Sincronizamos ReLead con el ERP académico y recuperamos el 30% de los prospectos inactivos antes del inicio de ciclo.”</p>
+          <div class="success-card__meta">
+            <span class="success-card__author">Universidad Horizonte</span>
+            <p class="success-card__role">Dirección de Admisiones</p>
+          </div>
+        </article>
+        <article class="success-card" role="listitem">
+          <p class="success-card__quote">“Los tableros de productividad nos ayudaron a priorizar llamadas y duplicar el volumen de entrevistas completadas.”</p>
+          <div class="success-card__meta">
+            <span class="success-card__author">Red Instituto Valle</span>
+            <p class="success-card__role">Coordinación Comercial</p>
+          </div>
+        </article>
+        <article class="success-card" role="listitem">
+          <p class="success-card__quote">“Automatizamos recordatorios por WhatsApp y correo; ahora cada asesor dispone de un histórico único por lead.”</p>
+          <div class="success-card__meta">
+            <span class="success-card__author">Colegio Delta</span>
+            <p class="success-card__role">Gerencia de Experiencia</p>
+          </div>
+        </article>
+      </div>
+    </section>
   </div>
   <div class="loading-overlay hidden" id="globalLoading" role="status" aria-live="polite" aria-hidden="true">
     <div class="loading-card">


### PR DESCRIPTION
## Summary
- Reestructura la pantalla inicial para incorporar un hero con titulares, CTAs y carrusel de métricas basado en la paleta existente
- Añade bloque de "Casos de éxito" con tarjetas reutilizables que aprovechan radios y sombras configuradas
- Documenta wireframes, copy sugerido y lineamientos responsive en `docs/diseno/landing.md`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce2562d8c832c844eb18c34b80b7a