### PR TITLE
Adjust login safe area padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,10 @@
       align-items:stretch;
       justify-content:center;
       padding:calc(var(--space) * 2) clamp(var(--space), 5vw, calc(var(--space) * 4));
+      padding-top:calc(var(--space) * 2 + constant(safe-area-inset-top));
+      padding-top:calc(var(--space) * 2 + env(safe-area-inset-top));
+      padding-bottom:calc(var(--space) * 2 + constant(safe-area-inset-bottom));
+      padding-bottom:calc(var(--space) * 2 + env(safe-area-inset-bottom));
       overflow-y:auto;
       background: radial-gradient(1200px 600px at 80% -10%, rgba(138,156,163,0.22), transparent 60%), radial-gradient(900px 500px at -10% 10%, rgba(0,58,95,0.25), transparent 60%), rgba(11,18,32,0.92);
       backdrop-filter: blur(8px);


### PR DESCRIPTION
## Summary
- add safe-area aware padding on the login overlay so it is no longer cropped by device notches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd7edc0f88832ca31a930c359d3a14