### PR TITLE
feat: add table view toggle for leads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1196,10 +1196,13 @@
     .table-wrap { background: var(--card); border:1px solid rgba(255,255,255,.08); border-radius: 16px; overflow:auto }
     table { width:100%; border-collapse: collapse; font-size:14px }
     thead th { position: sticky; top:0; background: linear-gradient(180deg, var(--card), var(--card-2)); text-align:left; padding:12px; border-bottom:1px solid rgba(255,255,255,.12); cursor:pointer }
+    thead th.is-sorted{ color: var(--accent); }
+    thead th.is-sorted::after{ content: attr(data-sort-dir); margin-left:6px; font-size:12px; }
     thead .filter-row th{ padding:8px 12px; border-bottom:1px solid rgba(255,255,255,.12); }
     .col-filter{ width:100%; padding:6px; border-radius:8px; border:1px solid rgba(255,255,255,.12); background:var(--card-2); color:var(--text); }
     tbody td { padding:12px; border-bottom: 1px dashed rgba(255,255,255,.08) }
     tbody tr:hover { background: rgba(0,58,95,.06) }
+    .table-empty{ text-align:center; padding:24px 12px; color:var(--muted); font-style:italic; }
     .preview-box{ color: var(--text); font-size:14px; }
     .preview-box .table-wrap{ margin-top:8px; }
     .preview-summary{ color: var(--muted); font-size:13px; margin-bottom:6px; }
@@ -2247,11 +2250,58 @@
           </div>
         </div>
         <div class="panel-section">
-          <h3>Leads</h3>
+          <div class="row between align-center" style="gap:var(--space-sm)">
+            <h3>Leads</h3>
+            <div class="seg" role="toolbar" aria-label="Formato de visualización">
+              <button type="button" data-view-mode="board" aria-pressed="true" title="Ver como tablero">
+                <i class="bi bi-kanban"></i> Tablero
+              </button>
+              <button type="button" data-view-mode="table" aria-pressed="false" title="Ver como tabla">
+                <i class="bi bi-table"></i> Tabla
+              </button>
+            </div>
+          </div>
           <section class="content">
             <!-- Kanban -->
             <div id="viewKanban" class="board" role="region" aria-label="Lead Board">
               <!-- Column templates -->
+            </div>
+            <div id="tableWrap" class="table-wrap hidden" role="region" aria-label="Tabla de leads">
+              <table>
+                <thead>
+                  <tr>
+                    <th data-sort="id">ID</th>
+                    <th data-sort="nombre">Nombre</th>
+                    <th data-sort="matricula">Matrícula</th>
+                    <th data-sort="correo">Correo</th>
+                    <th data-sort="telefono">Teléfono</th>
+                    <th data-sort="campus">Plantel</th>
+                    <th data-sort="modalidad">Modalidad</th>
+                    <th data-sort="programa">Programa</th>
+                    <th data-sort="etapa">Etapa</th>
+                    <th data-sort="estado">Estado</th>
+                    <th data-sort="asesor">Asesor</th>
+                    <th data-sort="comentario">Comentario</th>
+                    <th data-sort="asignacion">Asignación</th>
+                  </tr>
+                  <tr class="filter-row">
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="id" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="nombre" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="matricula" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="correo" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="telefono" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="campus" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="modalidad" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="programa" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="etapa" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="estado" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="asesor" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="comentario" /></th>
+                    <th><input class="col-filter" type="search" placeholder="Filtrar" data-col="asignacion" /></th>
+                  </tr>
+                </thead>
+                <tbody id="tbody"></tbody>
+              </table>
             </div>
           </section>
           <div id="paginator" class="pagination"></div>
@@ -3785,12 +3835,63 @@
     colFilters:Object.fromEntries(columns.map(k=>[k,''])),
     mobileColumns:{},
     columnLimits:{},
-    columnLimitSignature:''
+    columnLimitSignature:'',
+    viewMode:'board'
   });
   let state = createInitialState();
   const boardMobileQuery = window.matchMedia('(max-width: 700px)');
   const COLUMN_INITIAL_BATCH = 60;
   const COLUMN_BATCH_SIZE = 40;
+  const VIEW_MODES = new Set(['board','table']);
+
+  function normalizeViewMode(mode){
+    return VIEW_MODES.has(mode) ? mode : 'board';
+  }
+
+  function updateViewModeUI(){
+    const board = el('#viewKanban');
+    const table = el('#tableWrap');
+    if(board){
+      board.classList.toggle('hidden', state.viewMode !== 'board');
+    }
+    if(table){
+      table.classList.toggle('hidden', state.viewMode !== 'table');
+    }
+    els('[data-view-mode]').forEach(btn => {
+      if(!(btn instanceof HTMLElement)) return;
+      const btnMode = normalizeViewMode(btn.dataset.viewMode);
+      const isActive = btnMode === state.viewMode;
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      btn.classList.toggle('is-active', isActive);
+    });
+  }
+
+  function setViewMode(mode){
+    const normalized = normalizeViewMode(mode);
+    if(state.viewMode === normalized) return;
+    state.viewMode = normalized;
+    state.page = 0;
+    updateViewModeUI();
+    refresh();
+  }
+
+  function updateSortIndicators(){
+    const sortState = state.sort || {};
+    const { key, dir } = sortState;
+    els('th[data-sort]').forEach(th => {
+      const sortKey = th.dataset.sort;
+      if(key && sortKey === key){
+        th.setAttribute('aria-sort', dir === -1 ? 'descending' : 'ascending');
+        th.classList.add('is-sorted');
+        th.dataset.sortDir = dir === -1 ? '↓' : '↑';
+      }else{
+        th.removeAttribute('aria-sort');
+        th.classList.remove('is-sorted');
+        delete th.dataset.sortDir;
+      }
+    });
+  }
+
   const ensureColumnLimitState = () => {
     if(!state.columnLimits || typeof state.columnLimits !== 'object'){
       state.columnLimits = {};
@@ -8115,26 +8216,44 @@
   // —— Render Tabla ——
   function renderTabla(rows){
     const tbody = el('#tbody');
-
+    if(!tbody) return;
     tbody.innerHTML = '';
+    if(!Array.isArray(rows) || !rows.length){
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      td.colSpan = columns.length;
+      td.className = 'table-empty';
+      td.textContent = 'No hay leads que cumplan los filtros seleccionados.';
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+      return;
+    }
+    const formatValue = value => {
+      if(value === undefined || value === null || value === '') return '—';
+      return escapeHtml(String(value));
+    };
     rows.forEach(r => {
+      const etapaLabel = r.etapa || '—';
+      const etapaClass = etapaLabel === 'Inscrito' ? 'ok' : etapaLabel === 'Descartado' ? 'bad' : '';
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${r.id}</td>
-        <td>${r.nombre}</td>
-        <td>${r.matricula}</td>
-        <td>${r.correo}</td>
-        <td>${fmtPhone(r.telefono || r.telefonoNormalizado)}</td>
-        <td>${r.campus}</td>
-        <td>${r.modalidad}</td>
-        <td>${r.programa}</td>
-        <td><span class="tag ${r.etapa==='Inscrito'?'ok':''} ${r.etapa==='Descartado'?'bad':''}">${r.etapa}</span></td>
-        <td>${r.estado}</td>
-        <td>${displayAsesorName(r.asesor)}</td>
-        <td>${r.comentario}</td>
-        <td>${r.asignacion}</td>
+        <td>${formatValue(r.id)}</td>
+        <td>${formatValue(r.nombre)}</td>
+        <td>${formatValue(r.matricula)}</td>
+        <td>${formatValue(r.correo)}</td>
+        <td>${formatValue(fmtPhone(r.telefono || r.telefonoNormalizado))}</td>
+        <td>${formatValue(r.campus)}</td>
+        <td>${formatValue(r.modalidad)}</td>
+        <td>${formatValue(r.programa)}</td>
+        <td><span class="tag ${etapaClass}">${escapeHtml(etapaLabel)}</span></td>
+        <td>${formatValue(r.estado)}</td>
+        <td>${formatValue(displayAsesorName(r.asesor))}</td>
+        <td>${formatValue(r.comentario)}</td>
+        <td>${formatValue(r.asignacion)}</td>
       `;
       tr.addEventListener('click', ()=>openDetails(r));
+      tr.addEventListener('keypress', e=>{ if(e.key === 'Enter'){ openDetails(r); } });
+      tr.tabIndex = 0;
       tbody.appendChild(tr);
     });
   }
@@ -9656,10 +9775,43 @@
 
     // Filtros por columna
     els('input[data-col]').forEach(inp=>{
+      const colKey = inp.dataset.col;
+      if(colKey && state.colFilters && typeof state.colFilters[colKey] === 'string'){
+        inp.value = state.colFilters[colKey];
+      }
       inp.addEventListener('input', ()=>{
-        state.colFilters[inp.dataset.col] = inp.value.trim().toLowerCase();
+        const key = inp.dataset.col;
+        if(!key) return;
+        state.colFilters[key] = inp.value.trim().toLowerCase();
         state.page=0;
         refresh();
+      });
+    });
+
+    els('[data-view-mode]').forEach(btn => {
+      btn.addEventListener('click', ()=>{
+        setViewMode(btn.dataset.viewMode);
+      });
+    });
+
+    els('th[data-sort]').forEach(th => {
+      th.tabIndex = 0;
+      th.addEventListener('click', ()=>{
+        const key = th.dataset.sort;
+        if(!key) return;
+        if(state.sort && state.sort.key === key){
+          state.sort = { key, dir: state.sort.dir === 1 ? -1 : 1 };
+        }else{
+          state.sort = { key, dir: 1 };
+        }
+        state.page = 0;
+        refresh();
+      });
+      th.addEventListener('keypress', e => {
+        if(e.key === 'Enter' || e.key === ' '){
+          e.preventDefault();
+          th.click();
+        }
       });
     });
 
@@ -9741,8 +9893,14 @@
     const start = hasPagination ? state.page * state.pageSize : 0;
     const end = hasPagination ? start + state.pageSize : rows.length;
     const pageRows = rows.slice(start, end);
-    pruneColumnLimits(pageRows);
-    renderKanban(pageRows, totals);
+    if(state.viewMode === 'table'){
+      renderTabla(pageRows);
+    }else{
+      pruneColumnLimits(pageRows);
+      renderKanban(pageRows, totals);
+    }
+    updateViewModeUI();
+    updateSortIndicators();
   }
 
   async function initializeApp(){


### PR DESCRIPTION
## Summary
- add a segmented control to toggle between the Kanban board and a tabular view in the Leads panel
- implement the tabular layout with column filters, sorting indicators, and sanitized cell rendering
- sync pagination and view preferences so both board and table honor the existing filters and page size

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd81fdda50832cbdfc328389021208