### PR TITLE
Integrate drawer contact handlers and Aircall fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1277,6 +1277,39 @@
     html[data-theme="light"] .modal-footer{ border-top-color: rgba(15,23,42,0.08); }
     .modal-footnote{ margin-top:8px; font-size:12px; color:var(--muted); }
     body.modal-open{ overflow:hidden; }
+    .template-modal{ width:min(880px, 100%); }
+    .template-modal__grid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap:var(--space); align-items:flex-start; }
+    .template-modal__section{ display:flex; flex-direction:column; gap:var(--space-sm); }
+    .template-list{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+    .template-list__item{ display:flex; align-items:flex-start; gap:10px; justify-content:space-between; width:100%; border-radius:12px; border:1px solid rgba(255,255,255,0.1); padding:10px 12px; background:var(--card-2); color:var(--text); text-align:left; cursor:pointer; transition: transform .18s ease, box-shadow .18s ease; }
+    .template-list__item:hover, .template-list__item:focus-visible{ transform:translateY(-1px); box-shadow:0 12px 28px rgba(5,12,28,0.32); outline:none; }
+    .template-list__meta{ font-size:12px; opacity:0.7; margin-top:4px; }
+    .template-list__empty{ font-size:12px; color:var(--muted); padding:10px 12px; border-radius:12px; border:1px dashed rgba(255,255,255,0.18); background:rgba(148,163,184,0.08); text-align:center; }
+    .template-list__actions{ display:flex; gap:6px; }
+    .template-list__actions button{ border:none; background:color-mix(in srgb, rgba(255,255,255,0.08) 60%, var(--panel-base-soft) 40%); color:var(--text); border-radius:10px; padding:6px 10px; cursor:pointer; font-size:12px; transition: background .18s ease; }
+    .template-list__actions button:hover, .template-list__actions button:focus-visible{ background:color-mix(in srgb, rgba(255,255,255,0.12) 50%, var(--panel-base-bright) 50%); outline:none; }
+    .template-field{ display:flex; flex-direction:column; gap:6px; }
+    .template-field input,
+    .template-field textarea{ width:100%; border-radius:12px; border:1px solid rgba(255,255,255,0.18); padding:10px 12px; background:var(--card-2); color:var(--text); font:inherit; }
+    .template-field textarea{ resize:vertical; min-height:120px; }
+    .template-field input:focus,
+    .template-field textarea:focus{ outline:none; box-shadow:0 0 0 3px rgba(var(--panel-base-rgb),0.35); border-color:rgba(var(--panel-base-rgb),0.45); }
+    .template-hint{ margin:0; font-size:12px; color:var(--muted); }
+    .template-hint code{ background:rgba(148,163,184,0.16); padding:2px 6px; border-radius:8px; font-size:11px; }
+    .template-modal__actions{ display:flex; flex-wrap:wrap; gap:8px; justify-content:flex-end; }
+    .template-form{ margin-top:var(--space); padding:var(--space); border-radius:16px; border:1px solid rgba(255,255,255,0.12); background:color-mix(in srgb, var(--card-2) 80%, rgba(15,23,42,0.22) 20%); display:flex; flex-direction:column; gap:var(--space-sm); }
+    .template-form.hidden{ display:none; }
+    html[data-theme="light"] .template-list__item{ background:#ffffff; border-color:rgba(15,23,42,0.08); }
+    html[data-theme="light"] .template-list__empty{ background:#f8fafc; border-color:rgba(15,23,42,0.16); color:#475569; }
+    html[data-theme="light"] .template-list__actions button{ background:rgba(15,23,42,0.08); color:#0f172a; }
+    html[data-theme="light"] .template-list__actions button:hover, html[data-theme="light"] .template-list__actions button:focus-visible{ background:rgba(37,99,235,0.16); }
+    html[data-theme="light"] .template-field input,
+    html[data-theme="light"] .template-field textarea{ background:#ffffff; border-color:rgba(15,23,42,0.12); color:#0f172a; }
+    html[data-theme="light"] .template-form{ background:#ffffff; border-color:rgba(15,23,42,0.12); }
+    @media (max-width: 720px){
+      .template-modal__grid{ grid-template-columns:1fr; }
+      .template-modal__actions{ justify-content:flex-start; }
+    }
     /* Details panel */
     .panel {
       position: relative;
@@ -1301,8 +1334,8 @@
       line-height:1.6;
     }
     .panel.show { opacity:1; transform: translateY(0) scale(1); }
-    .panel-header { margin-bottom:20px; }
-    .panel-title { margin:0; display:flex; align-items:flex-start; gap:14px; font-size:26px; line-height:1.05; }
+    .panel-header { margin-bottom:20px; display:flex; align-items:flex-start; gap:12px; justify-content:space-between; }
+    .panel-title { margin:0; display:flex; align-items:flex-start; gap:14px; font-size:26px; line-height:1.05; flex:1 1 auto; }
     .panel-title span:first-child{ font-weight:800; font-size:1.04em; letter-spacing:.4px; flex:1 1 auto; min-width:0; }
     .panel[data-etapa] .panel-title span:first-child{ color:var(--panel-tone-text); text-shadow:none; }
     html[data-theme="light"] .panel{
@@ -1473,6 +1506,70 @@
       box-shadow: 0 12px 26px rgba(15,23,42,0.16);
       color: var(--panel-tone-text);
     }
+    .panel-favorite{
+      margin-top:6px;
+      border:none;
+      background:color-mix(in srgb, var(--panel-tone-soft) 70%, rgba(15,23,42,0.4) 30%);
+      color:var(--panel-tone-text);
+      border-radius:12px;
+      padding:8px 10px;
+      cursor:pointer;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      transition: transform .18s ease, box-shadow .18s ease, background .18s ease;
+    }
+    .panel-favorite i{ font-size:18px; }
+    .panel-favorite:hover, .panel-favorite:focus-visible{
+      transform:translateY(-1px);
+      box-shadow:0 10px 24px rgba(5,12,28,0.35);
+      outline:none;
+    }
+    .panel-favorite[aria-pressed="true"]{ background:rgba(255,215,0,0.16); color:#fde68a; }
+    html[data-theme="light"] .panel-favorite{ background:color-mix(in srgb, #ffffff 85%, var(--panel-tone-bright) 15%); color:#1f2937; }
+    html[data-theme="light"] .panel-favorite[aria-pressed="true"]{ background:#fef3c7; color:#b45309; }
+    .quick-access{
+      margin-top:12px;
+      padding:16px;
+      border-radius:16px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-strong) 35%, rgba(15,23,42,0.55) 65%);
+      background:color-mix(in srgb, var(--panel-tone-soft) 75%, rgba(15,23,42,0.4) 25%);
+      display:flex;
+      flex-direction:column;
+      gap:14px;
+    }
+    .quick-access__header h4{ margin:0; font-size:16px; font-weight:700; }
+    .quick-access__header p{ margin:4px 0 0; font-size:13px; color:var(--panel-tone-text); opacity:0.7; }
+    .quick-access__group{ display:flex; flex-direction:column; gap:8px; }
+    .quick-access__label{ font-size:13px; letter-spacing:.3px; text-transform:uppercase; color:var(--panel-tone-text); opacity:0.8; }
+    .quick-access__list{ display:flex; flex-wrap:wrap; gap:8px; }
+    .quick-access__item{
+      display:flex;
+      flex-direction:column;
+      align-items:flex-start;
+      gap:2px;
+      min-width:140px;
+      border-radius:12px;
+      border:1px solid color-mix(in srgb, var(--panel-tone-bright) 40%, rgba(15,23,42,0.5) 60%);
+      padding:10px 12px;
+      background:color-mix(in srgb, var(--panel-tone-soft) 82%, rgba(15,23,42,0.45) 18%);
+      color:var(--panel-tone-text);
+      font-size:13px;
+      text-align:left;
+      cursor:pointer;
+      transition: transform .18s ease, box-shadow .18s ease;
+    }
+    .quick-access__item:hover, .quick-access__item:focus-visible{
+      transform:translateY(-1px);
+      box-shadow:0 12px 28px rgba(5,12,28,0.32);
+      outline:none;
+    }
+    .quick-access__item-name{ font-weight:700; font-size:13px; }
+    .quick-access__item-meta{ font-size:12px; opacity:0.75; display:flex; gap:4px; flex-wrap:wrap; }
+    .quick-access__empty{ margin:0; font-size:12px; color:var(--panel-tone-text); opacity:0.6; }
+    html[data-theme="light"] .quick-access{ background:color-mix(in srgb, #ffffff 85%, var(--panel-tone-soft) 15%); border-color:color-mix(in srgb, var(--panel-tone-strong) 28%, #cbd5f5 72%); }
+    html[data-theme="light"] .quick-access__item{ background:#ffffff; border-color:color-mix(in srgb, var(--panel-tone-strong) 22%, #dbeafe 78%); }
+    html[data-theme="light"] .quick-access__item:hover, html[data-theme="light"] .quick-access__item:focus-visible{ box-shadow:0 12px 26px rgba(15,23,42,0.18); }
 
     .panel-overlay { position: fixed; inset: 0; display:flex; justify-content:center; align-items:center; padding:40px; background: var(--bg-soft); opacity:0; pointer-events:none; transition: opacity .24s ease; z-index: 60; }
     .panel-overlay.open { opacity:1; pointer-events:auto; }
@@ -2087,6 +2184,113 @@
       </div>
     </div>
   </div>
+  <div class="modal-overlay" id="whatsappTemplateModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-card template-modal" role="document">
+      <button type="button" class="modal-close" id="waModalClose" aria-label="Cerrar selección de plantillas">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+      <div class="modal-header">
+        <h2>Enviar por WhatsApp</h2>
+        <p>Elige una plantilla, personaliza el mensaje y envíalo sin salir de la plataforma.</p>
+      </div>
+      <div class="modal-body">
+        <div class="template-modal__grid">
+          <section class="template-modal__section">
+            <h3>Plantillas guardadas</h3>
+            <ul class="template-list" id="waTemplateList" role="list"></ul>
+            <button type="button" class="btn outline" id="waCreateTemplate"><i class="bi bi-plus-lg"></i> Nueva plantilla</button>
+          </section>
+          <section class="template-modal__section">
+            <label class="template-field">
+              <span>Mensaje a enviar</span>
+              <textarea id="waMessage" rows="6"></textarea>
+            </label>
+            <p class="template-hint">Usa <code>{{nombre}}</code> en tus plantillas para insertar automáticamente el nombre del lead.</p>
+            <div class="template-modal__actions">
+              <button type="button" class="btn" id="waCancelBtn">Cancelar</button>
+              <button type="button" class="btn primary" id="waSendBtn"><i class="bi bi-whatsapp"></i> Enviar por WhatsApp</button>
+            </div>
+          </section>
+        </div>
+        <form class="template-form hidden" id="waTemplateForm">
+          <input type="hidden" id="waTemplateId" />
+          <label class="template-field">
+            <span>Nombre de la plantilla</span>
+            <input type="text" id="waTemplateName" maxlength="80" required />
+          </label>
+          <label class="template-field">
+            <span>Mensaje</span>
+            <textarea id="waTemplateContent" rows="5" required></textarea>
+          </label>
+          <div class="template-modal__actions">
+            <button type="submit" class="btn primary" id="waTemplateSave">Guardar</button>
+            <button type="button" class="btn" id="waTemplateCancel">Cerrar</button>
+            <button type="button" class="btn danger" id="waTemplateDelete">Eliminar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="modal-overlay" id="emailTemplateModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="modal-card template-modal" role="document">
+      <button type="button" class="modal-close" id="emailModalClose" aria-label="Cerrar selección de plantillas de correo">
+        <i class="bi bi-x-lg" aria-hidden="true"></i>
+      </button>
+      <div class="modal-header">
+        <h2>Enviar correo</h2>
+        <p>Selecciona una plantilla, personaliza el saludo y el enlace a tu WhatsApp.</p>
+      </div>
+      <div class="modal-body">
+        <div class="template-modal__grid">
+          <section class="template-modal__section">
+            <h3>Plantillas guardadas</h3>
+            <ul class="template-list" id="emailTemplateList" role="list"></ul>
+            <button type="button" class="btn outline" id="emailCreateTemplate"><i class="bi bi-plus-lg"></i> Nueva plantilla</button>
+          </section>
+          <section class="template-modal__section">
+            <label class="template-field">
+              <span>Asunto</span>
+              <input type="text" id="emailSubject" maxlength="140" />
+            </label>
+            <label class="template-field">
+              <span>Mensaje</span>
+              <textarea id="emailBody" rows="8"></textarea>
+            </label>
+            <label class="template-field">
+              <span>WhatsApp del asesor</span>
+              <input type="tel" id="advisorWhatsapp" inputmode="tel" placeholder="521XXXXXXXXXX" />
+            </label>
+            <p class="template-hint">Puedes usar <code>{{nombre}}</code> y <code>{{whatsapp}}</code> en tus plantillas para personalizar automáticamente.</p>
+            <div class="template-modal__actions">
+              <button type="button" class="btn" id="emailCancelBtn">Cancelar</button>
+              <button type="button" class="btn" id="emailMailtoBtn"><i class="bi bi-envelope"></i> Usar mailto</button>
+              <button type="button" class="btn primary" id="emailGmailBtn"><i class="bi bi-google"></i> Abrir en Gmail</button>
+            </div>
+          </section>
+        </div>
+        <form class="template-form hidden" id="emailTemplateForm">
+          <input type="hidden" id="emailTemplateId" />
+          <label class="template-field">
+            <span>Nombre de la plantilla</span>
+            <input type="text" id="emailTemplateName" maxlength="80" required />
+          </label>
+          <label class="template-field">
+            <span>Asunto</span>
+            <input type="text" id="emailTemplateSubject" maxlength="140" required />
+          </label>
+          <label class="template-field">
+            <span>Mensaje</span>
+            <textarea id="emailTemplateBody" rows="6" required></textarea>
+          </label>
+          <div class="template-modal__actions">
+            <button type="submit" class="btn primary" id="emailTemplateSave">Guardar</button>
+            <button type="button" class="btn" id="emailTemplateCancel">Cerrar</button>
+            <button type="button" class="btn danger" id="emailTemplateDelete">Eliminar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
   <div class="app hidden" id="app">
     <!-- Sidebar -->
     <aside class="sidebar" id="sidebar" aria-label="Navegación principal" aria-hidden="false">
@@ -2265,6 +2469,9 @@
               <span id="d-nombre">Selecciona un lead</span>
               <span class="stage-pill is-empty" id="d-etapa">—</span>
             </h3>
+            <button type="button" class="panel-favorite" id="favoriteToggle" aria-pressed="false" aria-label="Agregar a favoritos">
+              <i class="bi bi-star" aria-hidden="true"></i>
+            </button>
           </div>
           <div class="kv">
             <div class="kv-label" id="lab-matricula">Matrícula</div><div id="d-matricula">—</div>
@@ -2299,20 +2506,36 @@
             <div class="panel-quick__actions">
               <button class="btn primary" id="updateBtn">Guardar actualización</button>
               <div class="panel-quick__shortcuts" role="group" aria-label="Accesos rápidos de contacto">
-                <a class="btn contact-btn contact-call" id="act-call" href="#" target="_blank" rel="noopener"><i class="bi bi-telephone"></i> Llamar</a>
-                <a class="btn contact-btn contact-wa" id="act-wa" href="#" target="_blank" rel="noopener"><i class="bi bi-whatsapp"></i> WhatsApp</a>
-                <a class="btn contact-btn contact-mail" id="act-mail" href="#" target="_blank" rel="noopener"><i class="bi bi-envelope"></i> Email</a>
+                <a class="btn contact-btn contact-call" data-contact="call" href="#"><i class="bi bi-telephone"></i> Llamar</a>
+                <a class="btn contact-btn contact-wa" data-contact="whatsapp" href="#"><i class="bi bi-whatsapp"></i> WhatsApp</a>
+                <a class="btn contact-btn contact-mail" data-contact="email" href="#"><i class="bi bi-envelope"></i> Email</a>
               </div>
             </div>
+            <section class="quick-access" id="quickAccessPanel" aria-label="Accesos rápidos de leads">
+              <header class="quick-access__header">
+                <h4>Recientes y favoritos</h4>
+                <p>Accede a los leads clave que has abierto recientemente o marcado como favoritos.</p>
+              </header>
+              <div class="quick-access__group" id="favoriteGroup">
+                <div class="quick-access__label">Favoritos</div>
+                <div class="quick-access__list" id="favoriteLeads" role="list"></div>
+                <p class="quick-access__empty" id="favoriteEmpty">Marca un lead con la estrella para guardarlo aquí.</p>
+              </div>
+              <div class="quick-access__group" id="recentGroup">
+                <div class="quick-access__label">Recientes</div>
+                <div class="quick-access__list" id="recentLeads" role="list"></div>
+                <p class="quick-access__empty" id="recentEmpty">Los leads que abras aparecerán en esta lista.</p>
+              </div>
+            </section>
             <p class="contact-scripts__status hidden" id="contactScriptStatus" role="status" aria-live="polite"></p>
           </div>
           <div class="actions" style="margin-top:10px">
             <button class="btn primary" id="updateBtn">Guardar</button>
           </div>
           <div class="actions" style="margin-top:10px">
-              <a class="btn contact-btn contact-call" id="act-call" href="#" target="_blank" rel="noopener"><i class="bi bi-telephone"></i> Llamar</a>
-              <a class="btn contact-btn contact-wa" id="act-wa" href="#" target="_blank" rel="noopener"><i class="bi bi-whatsapp"></i> WhatsApp</a>
-              <a class="btn contact-btn contact-mail" id="act-mail" href="#" target="_blank" rel="noopener"><i class="bi bi-envelope"></i> Email</a>
+              <a class="btn contact-btn contact-call" data-contact="call" href="#"><i class="bi bi-telephone"></i> Llamar</a>
+              <a class="btn contact-btn contact-wa" data-contact="whatsapp" href="#"><i class="bi bi-whatsapp"></i> WhatsApp</a>
+              <a class="btn contact-btn contact-mail" data-contact="email" href="#"><i class="bi bi-envelope"></i> Email</a>
           </div>
         </aside>
       </div>
@@ -3303,7 +3526,14 @@
   const STORAGE_KEYS = {
     profile: 'pulseProfile',
     preferences: 'pulsePreferences',
-    password: 'pulsePasswordRequest'
+    password: 'pulsePasswordRequest',
+    favorites: 'pulseLeadFavorites',
+    recents: 'pulseLeadRecents',
+    whatsappTemplates: 'pulseWhatsappTemplates',
+    whatsappLastTemplate: 'pulseWhatsappLastTemplate',
+    emailTemplates: 'pulseEmailTemplates',
+    emailLastTemplate: 'pulseEmailLastTemplate',
+    advisorWhatsapp: 'pulseAdvisorWhatsapp'
   };
   const DEFAULT_PASSWORD_REQUEST = {
     status: 'idle',
@@ -6485,17 +6715,20 @@
           });
         }
         leads = mapped;
+        syncQuickAccessWithLeads();
         state.columnLimits = {};
         state.columnLimitSignature = '';
       }else if(data && data.error){
         throw new Error(data.error);
       }else{
         leads = [];
+        syncQuickAccessWithLeads();
       }
     }catch(err){
       if(err && err.code === 'UNAUTHORIZED') return;
       console.error('Error al cargar leads', err);
       leads = [];
+      syncQuickAccessWithLeads();
     }
   }
 
@@ -6678,6 +6911,891 @@
     }catch(err){
       console.warn('No se pudo eliminar', key, err);
     }
+  }
+  function readStorageValue(key){
+    try{
+      return localStorage.getItem(key) || '';
+    }catch(err){
+      console.warn('No se pudo leer', key, err);
+      return '';
+    }
+  }
+  function writeStorageValue(key, value){
+    try{
+      if(value === undefined || value === null || value === ''){
+        localStorage.removeItem(key);
+      }else{
+        localStorage.setItem(key, String(value));
+      }
+    }catch(err){
+      console.warn('No se pudo guardar', key, err);
+    }
+  }
+  const QUICK_ACCESS_FAVORITES_LIMIT = 20;
+  const QUICK_ACCESS_RECENTS_LIMIT = 10;
+  const WHATSAPP_TEMPLATE_LIMIT = 30;
+  const EMAIL_TEMPLATE_LIMIT = 30;
+  const CUSTOM_TEMPLATE_KEY = '__custom__';
+  let quickAccessFavorites = loadQuickAccessList(STORAGE_KEYS.favorites);
+  let quickAccessRecents = loadQuickAccessList(STORAGE_KEYS.recents);
+  let quickAccessInitialized = false;
+  let currentLeadRecord = null;
+  let whatsappTemplates = loadWhatsappTemplates();
+  let whatsappLastTemplateId = readStorageValue(STORAGE_KEYS.whatsappLastTemplate) || '';
+  let emailTemplates = loadEmailTemplates();
+  let emailLastTemplateId = readStorageValue(STORAGE_KEYS.emailLastTemplate) || '';
+  let advisorWhatsappNumber = readStorageValue(STORAGE_KEYS.advisorWhatsapp) || '';
+  let whatsappTemplateFormEditingId = '';
+  let emailTemplateFormEditingId = '';
+  const whatsappModalState = { lead: null, digits: '', defaultMessage: '', onSend: null, selectedId: '' };
+  const emailModalState = { lead: null, email: '', defaultSubject: '', defaultBody: '', mailtoFallback: '', onSend: null, selectedId: '' };
+  let whatsappModalReady = false;
+  let emailModalReady = false;
+
+  function normalizeLeadId(value){
+    return String(value || '').trim();
+  }
+
+  function loadQuickAccessList(key){
+    const stored = readStorageJSON(key);
+    if(!Array.isArray(stored)) return [];
+    return stored
+      .map(entry => ({
+        id: normalizeLeadId(entry.id),
+        nombre: String(entry.nombre || '').trim(),
+        etapa: String(entry.etapa || '').trim(),
+        campus: String(entry.campus || '').trim(),
+        programa: String(entry.programa || '').trim(),
+        base: String(entry.base || '').trim(),
+        updatedAt: Number(entry.updatedAt) || 0
+      }))
+      .filter(entry => entry.id);
+  }
+
+  function saveQuickAccessList(key, list, limit){
+    if(!Array.isArray(list)) return;
+    const trimmed = list.slice(0, limit);
+    writeStorageJSON(key, trimmed);
+  }
+
+  function summarizeLeadForQuickAccess(lead){
+    if(!lead) return null;
+    const id = normalizeLeadId(lead.id);
+    if(!id) return null;
+    const etapa = etapaGroup(lead.etapa);
+    return {
+      id,
+      nombre: String(lead.nombre || '').trim(),
+      etapa,
+      campus: String(lead.campus || '').trim(),
+      programa: String(lead.programa || '').trim(),
+      base: String(lead.base || state.sheet || '').trim(),
+      updatedAt: Date.now()
+    };
+  }
+
+  function isLeadFavorite(id){
+    if(!id) return false;
+    return quickAccessFavorites.some(entry => entry.id === id);
+  }
+
+  function updateQuickAccessUI(){
+    if(!quickAccessInitialized) return;
+    const favoritesContainer = el('#favoriteLeads');
+    const favoritesEmpty = el('#favoriteEmpty');
+    renderQuickAccessList(favoritesContainer, favoritesEmpty, quickAccessFavorites);
+    const recentsContainer = el('#recentLeads');
+    const recentsEmpty = el('#recentEmpty');
+    renderQuickAccessList(recentsContainer, recentsEmpty, quickAccessRecents);
+    updateFavoriteToggleState();
+  }
+
+  function renderQuickAccessList(container, emptyEl, list){
+    if(!container) return;
+    container.innerHTML = '';
+    if(!Array.isArray(list) || !list.length){
+      if(emptyEl) emptyEl.classList.remove('hidden');
+      return;
+    }
+    if(emptyEl) emptyEl.classList.add('hidden');
+    list.forEach(entry => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'quick-access__item';
+      button.dataset.leadId = entry.id;
+      if(entry.base) button.dataset.leadBase = entry.base;
+      const metaParts = [entry.etapa || '', entry.campus || '', entry.programa || ''].filter(Boolean);
+      button.innerHTML = `<span class="quick-access__item-name">${escapeHtml(entry.nombre || 'Sin nombre')}</span>`+
+        (metaParts.length ? `<span class="quick-access__item-meta">${escapeHtml(metaParts.join(' · '))}</span>` : '');
+      container.appendChild(button);
+    });
+  }
+
+  function updateFavoriteToggleState(){
+    const button = el('#favoriteToggle');
+    if(!button) return;
+    const leadId = currentLeadRecord ? normalizeLeadId(currentLeadRecord.id) : '';
+    if(!leadId){
+      button.disabled = true;
+      button.setAttribute('aria-pressed', 'false');
+      button.title = 'Agrega un lead a favoritos';
+      button.innerHTML = '<i class="bi bi-star" aria-hidden="true"></i>';
+      return;
+    }
+    button.disabled = false;
+    const favored = isLeadFavorite(leadId);
+    button.setAttribute('aria-pressed', favored ? 'true' : 'false');
+    button.title = favored ? 'Quitar de favoritos' : 'Agregar a favoritos';
+    const icon = favored ? 'bi-star-fill' : 'bi-star';
+    button.innerHTML = `<i class="bi ${icon}" aria-hidden="true"></i>`;
+  }
+
+  function rememberRecentLead(lead){
+    const summary = summarizeLeadForQuickAccess(lead);
+    if(!summary) return;
+    quickAccessRecents = quickAccessRecents.filter(entry => entry.id !== summary.id);
+    summary.updatedAt = Date.now();
+    quickAccessRecents.unshift(summary);
+    if(quickAccessRecents.length > QUICK_ACCESS_RECENTS_LIMIT){
+      quickAccessRecents = quickAccessRecents.slice(0, QUICK_ACCESS_RECENTS_LIMIT);
+    }
+    saveQuickAccessList(STORAGE_KEYS.recents, quickAccessRecents, QUICK_ACCESS_RECENTS_LIMIT);
+    updateQuickAccessUI();
+  }
+
+  function setLeadFavorite(lead, shouldAdd){
+    const summary = summarizeLeadForQuickAccess(lead);
+    if(!summary) return;
+    quickAccessFavorites = quickAccessFavorites.filter(entry => entry.id !== summary.id);
+    if(shouldAdd){
+      quickAccessFavorites.unshift(summary);
+      if(quickAccessFavorites.length > QUICK_ACCESS_FAVORITES_LIMIT){
+        quickAccessFavorites = quickAccessFavorites.slice(0, QUICK_ACCESS_FAVORITES_LIMIT);
+      }
+    }
+    saveQuickAccessList(STORAGE_KEYS.favorites, quickAccessFavorites, QUICK_ACCESS_FAVORITES_LIMIT);
+    updateQuickAccessUI();
+  }
+
+  async function openQuickAccessLead(entry){
+    if(!entry || !entry.id) return;
+    const targetBase = entry.base ? entry.base : state.sheet;
+    if(targetBase && targetBase !== state.sheet){
+      try{
+        await withGlobalLoading('Cargando leads…', async () => {
+          state.sheet = targetBase;
+          syncSheetSelectorsUI();
+          await loadLeads();
+        });
+        syncQuickAccessWithLeads();
+        populateAsesores();
+        populateCampuses();
+        refresh();
+      }catch(err){
+        console.error('No se pudo cambiar la base para el acceso rápido', err);
+      }
+    }
+    const lead = leads.find(item => normalizeLeadId(item.id) === entry.id);
+    if(lead){
+      openDetails(lead);
+      return;
+    }
+    alert('No encontramos este lead en la base actual. Verifica si sigue disponible.');
+  }
+
+  function initQuickAccessUI(){
+    if(quickAccessInitialized) return;
+    const favoritesContainer = el('#favoriteLeads');
+    if(favoritesContainer){
+      favoritesContainer.addEventListener('click', event => {
+        const button = event.target.closest('.quick-access__item');
+        if(!button) return;
+        const id = button.dataset.leadId || '';
+        const base = button.dataset.leadBase || '';
+        openQuickAccessLead({ id, base });
+      });
+    }
+    const recentsContainer = el('#recentLeads');
+    if(recentsContainer){
+      recentsContainer.addEventListener('click', event => {
+        const button = event.target.closest('.quick-access__item');
+        if(!button) return;
+        const id = button.dataset.leadId || '';
+        const base = button.dataset.leadBase || '';
+        openQuickAccessLead({ id, base });
+      });
+    }
+    const toggle = el('#favoriteToggle');
+    if(toggle){
+      toggle.addEventListener('click', () => {
+        if(!currentLeadRecord) return;
+        const leadId = normalizeLeadId(currentLeadRecord.id);
+        if(!leadId) return;
+        const shouldAdd = !isLeadFavorite(leadId);
+        setLeadFavorite(currentLeadRecord, shouldAdd);
+      });
+    }
+    quickAccessInitialized = true;
+    updateQuickAccessUI();
+  }
+
+  function syncQuickAccessWithLeads(){
+    if(!Array.isArray(leads) || !leads.length) return;
+    const map = new Map();
+    leads.forEach(lead => {
+      const id = normalizeLeadId(lead.id);
+      if(id) map.set(id, lead);
+    });
+    let favChanged = false;
+    quickAccessFavorites = quickAccessFavorites.map(entry => {
+      const lead = map.get(entry.id);
+      if(!lead) return entry;
+      const summary = summarizeLeadForQuickAccess(lead);
+      if(!summary) return entry;
+      const updated = { ...entry, ...summary, updatedAt: entry.updatedAt || summary.updatedAt };
+      if(entry.nombre !== updated.nombre || entry.etapa !== updated.etapa || entry.campus !== updated.campus || entry.programa !== updated.programa || entry.base !== updated.base){
+        favChanged = true;
+      }
+      return updated;
+    });
+    if(favChanged){
+      saveQuickAccessList(STORAGE_KEYS.favorites, quickAccessFavorites, QUICK_ACCESS_FAVORITES_LIMIT);
+    }
+    let recChanged = false;
+    quickAccessRecents = quickAccessRecents.map(entry => {
+      const lead = map.get(entry.id);
+      if(!lead) return entry;
+      const summary = summarizeLeadForQuickAccess(lead);
+      if(!summary) return entry;
+      const updated = { ...entry, ...summary, updatedAt: entry.updatedAt || summary.updatedAt };
+      if(entry.nombre !== updated.nombre || entry.etapa !== updated.etapa || entry.campus !== updated.campus || entry.programa !== updated.programa || entry.base !== updated.base){
+        recChanged = true;
+      }
+      return updated;
+    });
+    if(recChanged){
+      saveQuickAccessList(STORAGE_KEYS.recents, quickAccessRecents, QUICK_ACCESS_RECENTS_LIMIT);
+    }
+    updateQuickAccessUI();
+  }
+
+  function generateTemplateId(prefix){
+    const base = prefix || 'tpl';
+    return `${base}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function loadWhatsappTemplates(){
+    const stored = readStorageJSON(STORAGE_KEYS.whatsappTemplates);
+    if(!Array.isArray(stored)) return [];
+    return stored
+      .map(item => {
+        const id = item && item.id ? String(item.id).trim() : generateTemplateId('wa');
+        const name = item && item.name !== undefined ? String(item.name).trim() : '';
+        const message = item && (item.message !== undefined ? String(item.message) : String(item.body || '')).trim();
+        if(!id) return null;
+        return {
+          id,
+          name: name || 'Plantilla sin nombre',
+          message
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function saveWhatsappTemplates(list){
+    whatsappTemplates = Array.isArray(list) ? list.slice(0, WHATSAPP_TEMPLATE_LIMIT) : [];
+    writeStorageJSON(STORAGE_KEYS.whatsappTemplates, whatsappTemplates);
+  }
+
+  function loadEmailTemplates(){
+    const stored = readStorageJSON(STORAGE_KEYS.emailTemplates);
+    if(!Array.isArray(stored)) return [];
+    return stored
+      .map(item => {
+        const id = item && item.id ? String(item.id).trim() : generateTemplateId('email');
+        const name = item && item.name !== undefined ? String(item.name).trim() : '';
+        const subject = item && item.subject !== undefined ? String(item.subject).trim() : '';
+        const body = item && item.body !== undefined ? String(item.body).trim() : '';
+        if(!id) return null;
+        return {
+          id,
+          name: name || 'Plantilla sin nombre',
+          subject,
+          body
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function saveEmailTemplates(list){
+    emailTemplates = Array.isArray(list) ? list.slice(0, EMAIL_TEMPLATE_LIMIT) : [];
+    writeStorageJSON(STORAGE_KEYS.emailTemplates, emailTemplates);
+  }
+
+  function resetWhatsappTemplateForm(){
+    const form = el('#waTemplateForm');
+    if(!form) return;
+    form.classList.add('hidden');
+    form.reset();
+    whatsappTemplateFormEditingId = '';
+  }
+
+  function renderWhatsappTemplateList(selectedId){
+    const list = el('#waTemplateList');
+    if(!list) return;
+    list.innerHTML = '';
+    if(!whatsappTemplates.length){
+      list.innerHTML = '<li class="template-list__empty">No tienes plantillas guardadas.</li>';
+      return;
+    }
+    whatsappTemplates.forEach(template => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'template-list__item';
+      button.dataset.templateId = template.id;
+      const preview = template.message ? `<div class="template-list__meta">${escapeHtml(template.message.slice(0, 120))}</div>` : '';
+      button.innerHTML = `<div><strong>${escapeHtml(template.name)}</strong>${preview}</div>`;
+      li.appendChild(button);
+      const actions = document.createElement('div');
+      actions.className = 'template-list__actions';
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.dataset.action = 'edit';
+      editBtn.dataset.templateId = template.id;
+      editBtn.textContent = 'Editar';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.dataset.action = 'delete';
+      deleteBtn.dataset.templateId = template.id;
+      deleteBtn.textContent = 'Eliminar';
+      actions.appendChild(editBtn);
+      actions.appendChild(deleteBtn);
+      li.appendChild(actions);
+      list.appendChild(li);
+    });
+    if(selectedId){
+      selectWhatsappTemplate(selectedId);
+    }
+  }
+
+  function selectWhatsappTemplate(templateId){
+    const messageInput = el('#waMessage');
+    if(!messageInput) return;
+    const template = whatsappTemplates.find(item => item.id === templateId);
+    if(!template){
+      whatsappModalState.selectedId = '';
+      return;
+    }
+    messageInput.value = template.message || '';
+    whatsappModalState.selectedId = template.id;
+  }
+
+  function startWhatsappTemplateEdit(templateId){
+    const form = el('#waTemplateForm');
+    const nameInput = el('#waTemplateName');
+    const contentInput = el('#waTemplateContent');
+    if(!form || !nameInput || !contentInput) return;
+    const template = whatsappTemplates.find(item => item.id === templateId);
+    whatsappTemplateFormEditingId = template ? template.id : '';
+    if(template){
+      nameInput.value = template.name || '';
+      contentInput.value = template.message || '';
+    }else{
+      nameInput.value = '';
+      contentInput.value = '';
+    }
+    form.classList.remove('hidden');
+    nameInput.focus();
+  }
+
+  function initWhatsAppModal(){
+    if(whatsappModalReady) return;
+    const overlay = el('#whatsappTemplateModal');
+    const closeBtn = el('#waModalClose');
+    const cancelBtn = el('#waCancelBtn');
+    const sendBtn = el('#waSendBtn');
+    const createBtn = el('#waCreateTemplate');
+    const list = el('#waTemplateList');
+    const form = el('#waTemplateForm');
+    const formCancel = el('#waTemplateCancel');
+    const formDelete = el('#waTemplateDelete');
+    if(overlay){
+      overlay.addEventListener('click', event => {
+        if(event.target === overlay) hideWhatsAppModal();
+      });
+    }
+    if(closeBtn) closeBtn.addEventListener('click', hideWhatsAppModal);
+    if(cancelBtn) cancelBtn.addEventListener('click', hideWhatsAppModal);
+    if(sendBtn) sendBtn.addEventListener('click', handleWhatsappSend);
+    if(createBtn) createBtn.addEventListener('click', () => {
+      startWhatsappTemplateEdit('');
+    });
+    if(list){
+      list.addEventListener('click', event => {
+        const target = event.target.closest('button');
+        if(!target) return;
+        const id = target.dataset.templateId || '';
+        const action = target.dataset.action || '';
+        if(action === 'edit'){
+          startWhatsappTemplateEdit(id);
+          return;
+        }
+        if(action === 'delete'){
+          whatsappTemplateFormEditingId = id;
+          handleWhatsappTemplateDelete();
+          return;
+        }
+        selectWhatsappTemplate(id);
+        whatsappLastTemplateId = id;
+      });
+    }
+    if(form) form.addEventListener('submit', handleWhatsappTemplateSave);
+    if(formCancel) formCancel.addEventListener('click', resetWhatsappTemplateForm);
+    if(formDelete) formDelete.addEventListener('click', handleWhatsappTemplateDelete);
+    whatsappModalReady = true;
+  }
+
+  function hideWhatsAppModal(){
+    const overlay = el('#whatsappTemplateModal');
+    if(overlay){
+      overlay.classList.remove('active');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+    document.body.classList.remove('modal-open');
+    resetWhatsappTemplateForm();
+    whatsappModalState.lead = null;
+    whatsappModalState.digits = '';
+    whatsappModalState.defaultMessage = '';
+    whatsappModalState.onSend = null;
+    whatsappModalState.selectedId = '';
+  }
+
+  function showWhatsAppModal(options){
+    initWhatsAppModal();
+    const overlay = el('#whatsappTemplateModal');
+    const messageInput = el('#waMessage');
+    if(!overlay || !messageInput) return;
+    const digits = String(options?.digits || '').replace(/\D/g, '');
+    if(!digits){
+      alert('No hay un número válido de WhatsApp para este lead.');
+      return;
+    }
+    whatsappModalState.lead = options?.lead || null;
+    whatsappModalState.digits = digits;
+    whatsappModalState.defaultMessage = options?.defaultMessage || '';
+    whatsappModalState.onSend = typeof options?.onSend === 'function' ? options.onSend : null;
+    whatsappModalState.selectedId = '';
+    resetWhatsappTemplateForm();
+    renderWhatsappTemplateList(whatsappLastTemplateId && whatsappLastTemplateId !== CUSTOM_TEMPLATE_KEY ? whatsappLastTemplateId : '');
+    if(whatsappLastTemplateId === CUSTOM_TEMPLATE_KEY && whatsappModalState.defaultMessage){
+      messageInput.value = whatsappModalState.defaultMessage;
+    }else if(whatsappLastTemplateId && whatsappLastTemplateId !== CUSTOM_TEMPLATE_KEY){
+      selectWhatsappTemplate(whatsappLastTemplateId);
+    }else{
+      messageInput.value = whatsappModalState.defaultMessage || '';
+    }
+    overlay.classList.add('active');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    messageInput.focus();
+  }
+
+  function handleWhatsappTemplateSave(event){
+    event.preventDefault();
+    const nameInput = el('#waTemplateName');
+    const contentInput = el('#waTemplateContent');
+    if(!nameInput || !contentInput) return;
+    const name = nameInput.value.trim();
+    const content = contentInput.value.trim();
+    if(!content){
+      alert('Ingresa el contenido de la plantilla.');
+      return;
+    }
+    let savedId = whatsappTemplateFormEditingId;
+    if(whatsappTemplateFormEditingId){
+      const existing = whatsappTemplates.find(item => item.id === whatsappTemplateFormEditingId);
+      if(existing){
+        existing.name = name || existing.name;
+        existing.message = content;
+      }
+    }else{
+      const id = generateTemplateId('wa');
+      whatsappTemplates.unshift({ id, name: name || 'Plantilla sin nombre', message: content });
+      savedId = id;
+    }
+    saveWhatsappTemplates(whatsappTemplates);
+    resetWhatsappTemplateForm();
+    renderWhatsappTemplateList(savedId);
+    if(savedId){
+      whatsappLastTemplateId = savedId;
+      writeStorageValue(STORAGE_KEYS.whatsappLastTemplate, savedId);
+    }
+  }
+
+  function handleWhatsappTemplateDelete(){
+    if(!whatsappTemplateFormEditingId) return;
+    if(!confirm('¿Eliminar la plantilla seleccionada?')) return;
+    whatsappTemplates = whatsappTemplates.filter(item => item.id !== whatsappTemplateFormEditingId);
+    saveWhatsappTemplates(whatsappTemplates);
+    if(whatsappLastTemplateId === whatsappTemplateFormEditingId){
+      whatsappLastTemplateId = '';
+      writeStorageValue(STORAGE_KEYS.whatsappLastTemplate, '');
+    }
+    resetWhatsappTemplateForm();
+    renderWhatsappTemplateList('');
+  }
+
+  function handleWhatsappSend(){
+    const messageInput = el('#waMessage');
+    if(!messageInput) return;
+    const digits = whatsappModalState.digits;
+    if(!digits){
+      alert('No hay un número válido de WhatsApp para este lead.');
+      return;
+    }
+    const leadName = String(whatsappModalState.lead?.nombre || '').trim();
+    let message = messageInput.value.trim();
+    if(!message){
+      message = whatsappModalState.defaultMessage || '';
+    }
+    if(leadName){
+      if(message.includes('{{nombre}}')){
+        message = message.replace(/\{\{nombre\}\}/gi, leadName);
+      }else{
+        message = `${leadName} ${message}`.trim();
+      }
+    }
+    if(!message){
+      alert('Escribe un mensaje para enviar.');
+      return;
+    }
+    const url = `https://wa.me/${digits}?text=${encodeURIComponent(message)}`;
+    window.open(url, '_blank', 'noopener');
+    const templateKey = whatsappModalState.selectedId || CUSTOM_TEMPLATE_KEY;
+    whatsappLastTemplateId = templateKey;
+    writeStorageValue(STORAGE_KEYS.whatsappLastTemplate, templateKey);
+    if(typeof whatsappModalState.onSend === 'function'){
+      whatsappModalState.onSend();
+    }
+    hideWhatsAppModal();
+  }
+
+  function resetEmailTemplateForm(){
+    const form = el('#emailTemplateForm');
+    if(!form) return;
+    form.classList.add('hidden');
+    form.reset();
+    emailTemplateFormEditingId = '';
+  }
+
+  function renderEmailTemplateList(selectedId){
+    const list = el('#emailTemplateList');
+    if(!list) return;
+    list.innerHTML = '';
+    if(!emailTemplates.length){
+      list.innerHTML = '<li class="template-list__empty">No tienes plantillas guardadas.</li>';
+      return;
+    }
+    emailTemplates.forEach(template => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'template-list__item';
+      button.dataset.templateId = template.id;
+      const preview = template.body ? `<div class="template-list__meta">${escapeHtml(template.body.slice(0, 120))}</div>` : '';
+      button.innerHTML = `<div><strong>${escapeHtml(template.name)}</strong>${preview}</div>`;
+      li.appendChild(button);
+      const actions = document.createElement('div');
+      actions.className = 'template-list__actions';
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.dataset.action = 'edit';
+      editBtn.dataset.templateId = template.id;
+      editBtn.textContent = 'Editar';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.dataset.action = 'delete';
+      deleteBtn.dataset.templateId = template.id;
+      deleteBtn.textContent = 'Eliminar';
+      actions.appendChild(editBtn);
+      actions.appendChild(deleteBtn);
+      li.appendChild(actions);
+      list.appendChild(li);
+    });
+    if(selectedId){
+      selectEmailTemplate(selectedId);
+    }
+  }
+
+  function selectEmailTemplate(templateId){
+    const subjectInput = el('#emailSubject');
+    const bodyInput = el('#emailBody');
+    if(!subjectInput || !bodyInput) return;
+    const template = emailTemplates.find(item => item.id === templateId);
+    if(!template){
+      emailModalState.selectedId = '';
+      return;
+    }
+    subjectInput.value = template.subject || '';
+    bodyInput.value = template.body || '';
+    emailModalState.selectedId = template.id;
+  }
+
+  function startEmailTemplateEdit(templateId){
+    const form = el('#emailTemplateForm');
+    const nameInput = el('#emailTemplateName');
+    const subjectInput = el('#emailTemplateSubject');
+    const bodyInput = el('#emailTemplateBody');
+    if(!form || !nameInput || !subjectInput || !bodyInput) return;
+    const template = emailTemplates.find(item => item.id === templateId);
+    emailTemplateFormEditingId = template ? template.id : '';
+    if(template){
+      nameInput.value = template.name || '';
+      subjectInput.value = template.subject || '';
+      bodyInput.value = template.body || '';
+    }else{
+      nameInput.value = '';
+      subjectInput.value = '';
+      bodyInput.value = '';
+    }
+    form.classList.remove('hidden');
+    nameInput.focus();
+  }
+
+  function initEmailModal(){
+    if(emailModalReady) return;
+    const overlay = el('#emailTemplateModal');
+    const closeBtn = el('#emailModalClose');
+    const cancelBtn = el('#emailCancelBtn');
+    const gmailBtn = el('#emailGmailBtn');
+    const mailtoBtn = el('#emailMailtoBtn');
+    const createBtn = el('#emailCreateTemplate');
+    const list = el('#emailTemplateList');
+    const form = el('#emailTemplateForm');
+    const formCancel = el('#emailTemplateCancel');
+    const formDelete = el('#emailTemplateDelete');
+    const advisorInput = el('#advisorWhatsapp');
+    if(overlay){
+      overlay.addEventListener('click', event => {
+        if(event.target === overlay) hideEmailModal();
+      });
+    }
+    if(closeBtn) closeBtn.addEventListener('click', hideEmailModal);
+    if(cancelBtn) cancelBtn.addEventListener('click', hideEmailModal);
+    if(gmailBtn) gmailBtn.addEventListener('click', () => handleEmailSend('gmail'));
+    if(mailtoBtn) mailtoBtn.addEventListener('click', () => handleEmailSend('mailto'));
+    if(createBtn) createBtn.addEventListener('click', () => startEmailTemplateEdit(''));
+    if(list){
+      list.addEventListener('click', event => {
+        const target = event.target.closest('button');
+        if(!target) return;
+        const id = target.dataset.templateId || '';
+        const action = target.dataset.action || '';
+        if(action === 'edit'){
+          startEmailTemplateEdit(id);
+          return;
+        }
+        if(action === 'delete'){
+          emailTemplateFormEditingId = id;
+          handleEmailTemplateDelete();
+          return;
+        }
+        selectEmailTemplate(id);
+        emailLastTemplateId = id;
+      });
+    }
+    if(form) form.addEventListener('submit', handleEmailTemplateSave);
+    if(formCancel) formCancel.addEventListener('click', resetEmailTemplateForm);
+    if(formDelete) formDelete.addEventListener('click', handleEmailTemplateDelete);
+    if(advisorInput){
+      advisorInput.addEventListener('blur', () => {
+        const normalized = normalizeWhatsappDigits(advisorInput.value);
+        advisorWhatsappNumber = normalized;
+        writeStorageValue(STORAGE_KEYS.advisorWhatsapp, normalized);
+        advisorInput.value = normalized;
+      });
+    }
+    emailModalReady = true;
+  }
+
+  function hideEmailModal(){
+    const overlay = el('#emailTemplateModal');
+    if(overlay){
+      overlay.classList.remove('active');
+      overlay.setAttribute('aria-hidden', 'true');
+    }
+    document.body.classList.remove('modal-open');
+    resetEmailTemplateForm();
+    emailModalState.lead = null;
+    emailModalState.email = '';
+    emailModalState.defaultSubject = '';
+    emailModalState.defaultBody = '';
+    emailModalState.mailtoFallback = '';
+    emailModalState.onSend = null;
+    emailModalState.selectedId = '';
+  }
+
+  function showEmailModal(options){
+    initEmailModal();
+    const overlay = el('#emailTemplateModal');
+    const subjectInput = el('#emailSubject');
+    const bodyInput = el('#emailBody');
+    const advisorInput = el('#advisorWhatsapp');
+    if(!overlay || !subjectInput || !bodyInput) return;
+    const email = String(options?.email || '').trim();
+    if(!email){
+      alert('No hay un correo válido para este lead.');
+      return;
+    }
+    emailModalState.lead = options?.lead || null;
+    emailModalState.email = email;
+    emailModalState.defaultSubject = options?.defaultSubject || '';
+    emailModalState.defaultBody = options?.defaultBody || '';
+    emailModalState.mailtoFallback = options?.mailtoFallback || '';
+    emailModalState.onSend = typeof options?.onSend === 'function' ? options.onSend : null;
+    emailModalState.selectedId = '';
+    resetEmailTemplateForm();
+    renderEmailTemplateList(emailLastTemplateId && emailLastTemplateId !== CUSTOM_TEMPLATE_KEY ? emailLastTemplateId : '');
+    if(emailLastTemplateId === CUSTOM_TEMPLATE_KEY){
+      subjectInput.value = emailModalState.defaultSubject || '';
+      bodyInput.value = emailModalState.defaultBody || '';
+    }else if(emailLastTemplateId){
+      selectEmailTemplate(emailLastTemplateId);
+    }else{
+      subjectInput.value = emailModalState.defaultSubject || '';
+      bodyInput.value = emailModalState.defaultBody || '';
+    }
+    if(advisorInput){
+      advisorInput.value = advisorWhatsappNumber;
+    }
+    overlay.classList.add('active');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('modal-open');
+    subjectInput.focus();
+  }
+
+  function handleEmailTemplateSave(event){
+    event.preventDefault();
+    const nameInput = el('#emailTemplateName');
+    const subjectInput = el('#emailTemplateSubject');
+    const bodyInput = el('#emailTemplateBody');
+    if(!nameInput || !subjectInput || !bodyInput) return;
+    const name = nameInput.value.trim();
+    const subject = subjectInput.value.trim();
+    const body = bodyInput.value.trim();
+    if(!subject || !body){
+      alert('Completa asunto y mensaje para guardar la plantilla.');
+      return;
+    }
+    let savedId = emailTemplateFormEditingId;
+    if(emailTemplateFormEditingId){
+      const existing = emailTemplates.find(item => item.id === emailTemplateFormEditingId);
+      if(existing){
+        existing.name = name || existing.name;
+        existing.subject = subject;
+        existing.body = body;
+      }
+    }else{
+      const id = generateTemplateId('email');
+      emailTemplates.unshift({ id, name: name || 'Plantilla sin nombre', subject, body });
+      savedId = id;
+    }
+    saveEmailTemplates(emailTemplates);
+    resetEmailTemplateForm();
+    renderEmailTemplateList(savedId);
+    if(savedId){
+      emailLastTemplateId = savedId;
+      writeStorageValue(STORAGE_KEYS.emailLastTemplate, savedId);
+    }
+  }
+
+  function handleEmailTemplateDelete(){
+    if(!emailTemplateFormEditingId) return;
+    if(!confirm('¿Eliminar la plantilla seleccionada?')) return;
+    emailTemplates = emailTemplates.filter(item => item.id !== emailTemplateFormEditingId);
+    saveEmailTemplates(emailTemplates);
+    if(emailLastTemplateId === emailTemplateFormEditingId){
+      emailLastTemplateId = '';
+      writeStorageValue(STORAGE_KEYS.emailLastTemplate, '');
+    }
+    resetEmailTemplateForm();
+    renderEmailTemplateList('');
+  }
+
+  function handleEmailSend(mode){
+    const subjectInput = el('#emailSubject');
+    const bodyInput = el('#emailBody');
+    const advisorInput = el('#advisorWhatsapp');
+    if(!subjectInput || !bodyInput) return;
+    const email = emailModalState.email;
+    if(!email){
+      alert('No hay un correo válido para este lead.');
+      return;
+    }
+    let subject = subjectInput.value.trim() || emailModalState.defaultSubject || '';
+    let body = bodyInput.value.trim() || emailModalState.defaultBody || '';
+    const leadName = String(emailModalState.lead?.nombre || '').trim();
+    const advisorRaw = advisorInput ? advisorInput.value : advisorWhatsappNumber;
+    const advisorDigits = normalizeWhatsappDigits(advisorRaw);
+    advisorWhatsappNumber = advisorDigits;
+    if(advisorInput) advisorInput.value = advisorDigits;
+    writeStorageValue(STORAGE_KEYS.advisorWhatsapp, advisorDigits);
+    const whatsappLink = advisorDigits ? `https://wa.me/${advisorDigits}` : '';
+    if(leadName){
+      if(subject.includes('{{nombre}}')){
+        subject = subject.replace(/\{\{nombre\}\}/gi, leadName);
+      }
+      if(body.includes('{{nombre}}')){
+        body = body.replace(/\{\{nombre\}\}/gi, leadName);
+      }else{
+        const greeting = `Hola ${leadName},`;
+        body = body ? `${greeting}\n\n${body}` : greeting;
+      }
+    }
+    if(whatsappLink){
+      if(subject.includes('{{whatsapp}}')){
+        subject = subject.replace(/\{\{whatsapp\}\}/gi, whatsappLink);
+      }
+      if(body.includes('{{whatsapp}}')){
+        body = body.replace(/\{\{whatsapp\}\}/gi, whatsappLink);
+      }else{
+        body = `${body}\n\nContáctame también por WhatsApp: ${whatsappLink}`.trim();
+      }
+    }else{
+      subject = subject.replace(/\{\{whatsapp\}\}/gi, '').trim();
+      body = body.replace(/\{\{whatsapp\}\}/gi, '').trim();
+    }
+    if(!subject || !body){
+      alert('Completa asunto y mensaje para enviar el correo.');
+      return;
+    }
+    const encodedSubject = encodeURIComponent(subject);
+    const encodedBody = encodeURIComponent(body);
+    if(mode === 'gmail'){
+      const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${encodeURIComponent(email)}&su=${encodedSubject}&body=${encodedBody}`;
+      window.open(gmailUrl, '_blank', 'noopener');
+    }else{
+      const mailtoUrl = `mailto:${encodeURIComponent(email)}?subject=${encodedSubject}&body=${encodedBody}`;
+      window.location.href = mailtoUrl;
+    }
+    const templateKey = emailModalState.selectedId || CUSTOM_TEMPLATE_KEY;
+    emailLastTemplateId = templateKey;
+    writeStorageValue(STORAGE_KEYS.emailLastTemplate, templateKey);
+    if(typeof emailModalState.onSend === 'function'){
+      emailModalState.onSend();
+    }
+    hideEmailModal();
+  }
+
+  function normalizeWhatsappDigits(value){
+    const text = String(value || '').trim();
+    if(!text) return '';
+    const parsed = parsePhone(text);
+    if(parsed && parsed.wa){
+      return parsed.wa.replace(/\D/g, '');
+    }
+    return text.replace(/\D/g, '');
   }
   function clearLegacyThemeKey(){
     try{
@@ -7792,6 +8910,102 @@
     return `${timestamp} · ${channel}: contacto registrado.`;
   }
 
+  const MOBILE_CALL_USER_AGENT = /android|iphone|ipad|ipod|iemobile|opera mini|blackberry|silk/i;
+
+  function isMobileCallEnvironment(){
+    if(typeof navigator === 'undefined') return false;
+    const ua = navigator.userAgent || navigator.vendor || '';
+    return MOBILE_CALL_USER_AGENT.test(ua);
+  }
+
+  function normalizeE164(value){
+    if(!value) return '';
+    const digits = String(value).trim();
+    if(!digits) return '';
+    return digits.startsWith('+') ? digits : `+${digits.replace(/^\+/, '')}`;
+  }
+
+  function openAircallLink(options = {}){
+    const normalized = normalizeE164(options.e164 || '');
+    const fallbackUrl = options.fallbackUrl || '';
+    const telUrl = options.telUrl || '';
+    const hasTel = Boolean(telUrl);
+    const hasFallback = Boolean(fallbackUrl);
+    const launchFallback = () => {
+      if(hasFallback){
+        window.open(fallbackUrl, '_blank', 'noopener');
+      }else if(hasTel){
+        window.location.href = telUrl;
+      }
+    };
+    if(isMobileCallEnvironment()){
+      if(hasTel){
+        window.location.href = telUrl;
+        return;
+      }
+      if(hasFallback){
+        window.open(fallbackUrl, '_blank', 'noopener');
+      }
+      return;
+    }
+    if(!normalized){
+      launchFallback();
+      return;
+    }
+    const protocolUrl = `aircall://call?number=${encodeURIComponent(normalized)}`;
+    let iframe = null;
+    let didFallback = false;
+    const cleanup = () => {
+      if(iframe && iframe.parentNode){
+        iframe.parentNode.removeChild(iframe);
+      }
+      iframe = null;
+    };
+    const triggerFallback = () => {
+      if(didFallback) return;
+      didFallback = true;
+      cleanup();
+      launchFallback();
+    };
+    const blurHandler = () => {
+      didFallback = true;
+      clearTimeout(timerId);
+      cleanup();
+      window.removeEventListener('blur', blurHandler);
+    };
+    const timerId = setTimeout(() => {
+      window.removeEventListener('blur', blurHandler);
+      triggerFallback();
+    }, 1800);
+    window.addEventListener('blur', blurHandler, { once: true });
+    try{
+      iframe = document.createElement('iframe');
+      iframe.style.display = 'none';
+      iframe.style.width = '0';
+      iframe.style.height = '0';
+      iframe.onload = () => {
+        clearTimeout(timerId);
+        window.removeEventListener('blur', blurHandler);
+        cleanup();
+      };
+      iframe.onerror = () => {
+        clearTimeout(timerId);
+        window.removeEventListener('blur', blurHandler);
+        triggerFallback();
+      };
+      iframe.src = protocolUrl;
+      document.body.appendChild(iframe);
+    }catch(err){
+      clearTimeout(timerId);
+      window.removeEventListener('blur', blurHandler);
+      triggerFallback();
+    }
+    setTimeout(() => {
+      window.removeEventListener('blur', blurHandler);
+      cleanup();
+    }, 4000);
+  }
+
   async function copyToClipboard(text){
     if(!text) return false;
     try{
@@ -8143,6 +9357,9 @@
   function openDetails(r){
     el('#d-nombre').textContent = r.nombre || '—';
     const basePhone = r.telefono || r.telefonoNormalizado || '';
+    currentLeadRecord = r;
+    updateFavoriteToggleState();
+    rememberRecentLead(r);
     const showField = (val,labelId,valueId,fmt)=>{
       const has = Boolean(val);
       const labelEl = el('#'+labelId);
@@ -8197,6 +9414,24 @@
     }else{
       hidePanelOverlay();
     }
+
+    let contactScripts = buildContactScripts(r);
+
+    const registerContactNote = type => {
+      const note = createContactNote(type, r);
+      if(!note) return;
+      const existing = String(r.comentario || '').trim();
+      const lines = existing ? existing.split(/\n+/).map(line => line.trim()).filter(Boolean) : [];
+      if(lines.includes(note)) return;
+      lines.push(note);
+      r.comentario = lines.join('\n');
+      formSets.forEach(set => {
+        if(set.comentarioInput){
+          set.comentarioInput.value = r.comentario;
+        }
+      });
+      syncSaveAvailability();
+    };
 
     const formSets = [];
     const canEditLead = canPerform('updateLead');
@@ -8418,7 +9653,7 @@
     };
 
     const applyContactScripts = () => {
-      const scripts = buildContactScripts(r);
+      contactScripts = buildContactScripts(r);
       broadcastScriptStatus('');
       ['contactScripts','drawerContactScripts'].forEach(id => {
         const container = document.getElementById(id);
@@ -8426,15 +9661,15 @@
         CONTACT_SCRIPT_TYPES.forEach(type => {
           const textEl = container.querySelector(`[data-script-text="${type}"]`);
           if(textEl){
-            textEl.value = scripts[type] || 'No hay guion disponible para este lead.';
+            textEl.value = contactScripts[type] || 'No hay guion disponible para este lead.';
           }
           const actionBtn = container.querySelector(`[data-script-apply="${type}"]`);
           if(actionBtn){
-            actionBtn.disabled = !scripts[type];
+            actionBtn.disabled = !contactScripts[type];
             actionBtn.onclick = async event => {
               event.preventDefault();
-              if(!scripts[type]) return;
-              const copied = await copyToClipboard(scripts[type]);
+              if(!contactScripts[type]) return;
+              const copied = await copyToClipboard(contactScripts[type]);
               registerContactNote(type);
               broadcastScriptStatus(copied ? `${CONTACT_CHANNEL_LABELS[type]} copiado. Completa la nota y guarda el lead.` : `${CONTACT_CHANNEL_LABELS[type]} registrado. Copia el guion manualmente si lo necesitas.`);
             };
@@ -8457,43 +9692,141 @@
     const phoneDigits = phone.intl || phone.digits;
     const waDigits = phone.wa || phoneDigits;
     const phoneDisplay = fmtPhone(basePhone);
-    const callHref = r.callUrl || (phoneDigits && phoneDigits.length >= 10 ? `https://dashboard.aircall.io/call/${phoneDigits}` : '');
-    const waHref = r.whatsappUrl || (waDigits && waDigits.length >= 10 ? `https://wa.me/${waDigits}` : '');
-    const mailHref = r.emailUrl || (r.correo ? `https://mail.google.com/mail/?view=cm&fs=1&to=${encodeURIComponent(r.correo)}&su=Seguimiento%20UNIDEP&body=Hola%20${encodeURIComponent(r.nombre)}%2C%20` : '');
+    const normalizedIntl = phoneDigits ? `+${String(phoneDigits).replace(/^\+/, '')}` : '';
+    const e164Number = normalizedIntl || '';
+    const telUrl = phone.local
+      ? (phone.local.length === 10 ? `tel:+52${phone.local}` : `tel:${phone.local}`)
+      : (phoneDigits ? `tel:${normalizedIntl || phoneDigits}` : '');
+    const callFallbackUrl = r.callUrl || (phoneDigits && phoneDigits.length >= 10 ? `https://dashboard.aircall.io/call/${phoneDigits}` : '');
+    const waHref = r.whatsappUrl || (waDigits && waDigits.length >= 8 ? `https://wa.me/${waDigits}` : '');
+    const mailtoHref = r.correo ? `mailto:${encodeURIComponent(r.correo)}` : '';
     const hasPhoneValue = Boolean(phoneDisplay);
-    const hasCallLink = Boolean(callHref);
-    const hasWaLink = Boolean(waHref);
-    const hasMailLink = Boolean(mailHref);
-    const actCall = el('#act-call');
-    const actWa = el('#act-wa');
-    const actMail = el('#act-mail');
-    if(actCall){
-      actCall.classList.toggle('hidden', !hasCallLink);
-      if(hasCallLink){
-        actCall.href = callHref;
-        actCall.onclick = () => { maybeRegisterContactNote('call'); };
-      }else{
-        actCall.onclick = null;
-      }
-    }
-    if(actWa){
-      actWa.classList.toggle('hidden', !hasWaLink);
-      if(hasWaLink){
-        actWa.href = waHref;
-        actWa.onclick = () => { maybeRegisterContactNote('whatsapp'); };
-      }else{
-        actWa.onclick = null;
-      }
-    }
-    if(actMail){
-      actMail.classList.toggle('hidden', !hasMailLink);
-      if(hasMailLink){
-        actMail.href = mailHref;
-        actMail.onclick = () => { maybeRegisterContactNote('email'); };
-      }else{
-        actMail.onclick = null;
-      }
-    }
+    const hasCallLink = Boolean(e164Number || callFallbackUrl || telUrl);
+    const hasWaLink = Boolean(waDigits && waDigits.length >= 8);
+    const hasMailLink = Boolean(r.correo);
+
+    const emailScript = contactScripts.email || '';
+    const emailLines = emailScript.split('\n');
+    const subjectLine = emailLines.length ? emailLines[0] : '';
+    const defaultEmailSubject = subjectLine && /^\s*Asunto:/i.test(subjectLine)
+      ? subjectLine.replace(/^\s*Asunto:\s*/i, '').trim()
+      : `Seguimiento UNIDEP ${r.programa || 'tu inscripción'}`;
+    const defaultEmailBody = emailLines.length > 1 ? emailLines.slice(1).join('\n').trim() : '';
+
+    const assignContactHandlers = (nodes, handler, linkOptions) => {
+      nodes.forEach(anchor => {
+        if(!anchor) return;
+        let hrefValue = '';
+        let targetValue = '';
+        let relValue = '';
+        let datasetValues = null;
+        if(typeof linkOptions === 'string'){
+          hrefValue = linkOptions;
+        }else if(linkOptions && typeof linkOptions === 'object'){
+          hrefValue = linkOptions.href || '';
+          targetValue = linkOptions.target || '';
+          relValue = linkOptions.rel || '';
+          datasetValues = linkOptions.dataset || null;
+        }
+        if(hrefValue){
+          anchor.href = hrefValue;
+        }else{
+          anchor.removeAttribute('href');
+        }
+        if(targetValue){
+          anchor.target = targetValue;
+        }else{
+          anchor.removeAttribute('target');
+        }
+        if(relValue){
+          anchor.rel = relValue;
+        }else{
+          anchor.removeAttribute('rel');
+        }
+        if(datasetValues && typeof datasetValues === 'object'){
+          Object.entries(datasetValues).forEach(([key, value]) => {
+            const dataKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+            if(value === undefined || value === null || value === ''){
+              delete anchor.dataset[key];
+              anchor.removeAttribute(`data-${dataKey}`);
+            }else{
+              anchor.dataset[key] = value;
+            }
+          });
+        }
+        if(handler){
+          anchor.classList.remove('hidden');
+          anchor.onclick = handler;
+        }else{
+          anchor.classList.add('hidden');
+          anchor.onclick = null;
+        }
+      });
+    };
+
+    const callHandler = hasCallLink ? event => {
+      event.preventDefault();
+      registerContactNote('call');
+      openAircallLink({ e164: e164Number, fallbackUrl: callFallbackUrl, telUrl });
+    } : null;
+
+    const whatsappHandler = hasWaLink ? event => {
+      event.preventDefault();
+      showWhatsAppModal({
+        lead: r,
+        digits: waDigits,
+        defaultMessage: contactScripts.whatsapp || '',
+        onSend: () => registerContactNote('whatsapp')
+      });
+    } : null;
+
+    const emailHandler = hasMailLink ? event => {
+      event.preventDefault();
+      showEmailModal({
+        lead: r,
+        email: r.correo,
+        defaultSubject: defaultEmailSubject,
+        defaultBody: defaultEmailBody,
+        mailtoFallback: mailtoHref,
+        onSend: () => registerContactNote('email')
+      });
+    } : null;
+
+    const applyPanelContactButtons = () => {
+      const panelEl = el('#panelOverlay .panel');
+      if(!panelEl) return;
+      const callButtons = Array.from(panelEl.querySelectorAll('[data-contact="call"]'));
+      const waButtons = Array.from(panelEl.querySelectorAll('[data-contact="whatsapp"]'));
+      const mailButtons = Array.from(panelEl.querySelectorAll('[data-contact="email"]'));
+      assignContactHandlers(callButtons, callHandler, {
+        href: callFallbackUrl || telUrl || '#',
+        dataset: {
+          fallbackHref: callFallbackUrl || '',
+          telHref: telUrl || ''
+        }
+      });
+      assignContactHandlers(waButtons, whatsappHandler, waHref || '#');
+      assignContactHandlers(mailButtons, emailHandler, mailtoHref || '#');
+    };
+
+    const applyDrawerContactButtons = () => {
+      const drawerContainer = document.getElementById('drawerContent');
+      if(!drawerContainer) return;
+      const callButtons = Array.from(drawerContainer.querySelectorAll('[data-drawer-contact="call"]'));
+      const waButtons = Array.from(drawerContainer.querySelectorAll('[data-drawer-contact="whatsapp"]'));
+      const mailButtons = Array.from(drawerContainer.querySelectorAll('[data-drawer-contact="email"]'));
+      assignContactHandlers(callButtons, callHandler, {
+        href: callFallbackUrl || telUrl || '#',
+        dataset: {
+          fallbackHref: callFallbackUrl || '',
+          telHref: telUrl || ''
+        }
+      });
+      assignContactHandlers(waButtons, whatsappHandler, waHref || '#');
+      assignContactHandlers(mailButtons, emailHandler, mailtoHref || '#');
+    };
+
+    applyPanelContactButtons();
 
     if (window.matchMedia('(max-width: 1200px)').matches){
       const drawer = el('#drawer');
@@ -8520,9 +9853,9 @@
         <section class="drawer-quick" aria-label="Actualiza y contacta">
           <p class="drawer-quick__hint">Actualiza etapa y estado antes de abrir un nuevo contacto.</p>
           <div class="drawer-quick__shortcuts" role="group" aria-label="Accesos rápidos de contacto">
-            ${hasCallLink?`<a class="btn" target="_blank" rel="noopener" href="${callHref}"><i class='bi bi-telephone'></i> Llamar</a>`:''}
-            ${hasWaLink?`<a class="btn" target="_blank" rel="noopener" href="${waHref}"><i class='bi bi-whatsapp'></i> WhatsApp</a>`:''}
-            ${hasMailLink?`<a class="btn" target="_blank" rel="noopener" href="${mailHref}"><i class='bi bi-envelope'></i> Email</a>`:''}
+            ${hasCallLink?`<a class="btn" id="drawerActCall" data-drawer-contact="call" href="#"><i class='bi bi-telephone'></i> Llamar</a>`:''}
+            ${hasWaLink?`<a class="btn" id="drawerActWa" data-drawer-contact="whatsapp" href="#"><i class='bi bi-whatsapp'></i> WhatsApp</a>`:''}
+            ${hasMailLink?`<a class="btn" id="drawerActMail" data-drawer-contact="email" href="#"><i class='bi bi-envelope'></i> Email</a>`:''}
           </div>
           <label class="drawer-quick__field">Etapa
             <select id="drawerEtapa" class="w100"></select>
@@ -8545,6 +9878,7 @@
         <div class="actions" style="margin-top:12px">
           <button class="btn primary" type="button" id="drawerUpdateBtn">Guardar</button>
         </div>`;
+      applyDrawerContactButtons();
       registerForm({
         etapaSelect: el('#drawerEtapa'),
         estadoSelect: el('#drawerEstado'),
@@ -8554,18 +9888,6 @@
         feedbackTitleEl: el('#drawerFeedbackTitle'),
         feedbackMessageEl: el('#drawerFeedbackMessage')
       });
-      const drawerCall = document.getElementById('drawerActCall');
-      if(drawerCall){
-        drawerCall.onclick = () => { maybeRegisterContactNote('call'); };
-      }
-      const drawerWa = document.getElementById('drawerActWa');
-      if(drawerWa){
-        drawerWa.onclick = () => { maybeRegisterContactNote('whatsapp'); };
-      }
-      const drawerMail = document.getElementById('drawerActMail');
-      if(drawerMail){
-        drawerMail.onclick = () => { maybeRegisterContactNote('email'); };
-      }
     }
     applyContactScripts();
     syncSaveAvailability();
@@ -9665,6 +10987,7 @@
 
     // Configuración y preferencias
     initSettings();
+    initQuickAccessUI();
 
     // Panel emergente
     const panelClose = el('#panelClose');


### PR DESCRIPTION
## Summary
- wire drawer contact buttons and shared handler assignment to the new contact workflows
- add an Aircall opener that prefers the custom protocol with controlled fallbacks for desktop and mobile
- persist the most recently saved WhatsApp and email templates to localStorage

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd89bd2c8c832c868208b70f72eb2e