### PR TITLE
Adjust login screen padding to avoid clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,11 +178,12 @@
       gap:calc(var(--space) * 1.5);
       align-items:stretch;
       justify-content:center;
-      padding:calc(var(--space) * 2) clamp(var(--space), 5vw, calc(var(--space) * 4));
-      padding-top:calc(var(--space) * 2 + constant(safe-area-inset-top));
-      padding-top:calc(var(--space) * 2 + env(safe-area-inset-top));
-      padding-bottom:calc(var(--space) * 2 + constant(safe-area-inset-bottom));
-      padding-bottom:calc(var(--space) * 2 + env(safe-area-inset-bottom));
+      padding-block:clamp(calc(var(--space) * 2), 8vh, calc(var(--space) * 4));
+      padding-inline:clamp(var(--space), 5vw, calc(var(--space) * 4));
+      padding-top:clamp(calc(var(--space) * 2 + constant(safe-area-inset-top)), 8vh, calc(var(--space) * 4 + constant(safe-area-inset-top)));
+      padding-top:clamp(calc(var(--space) * 2 + env(safe-area-inset-top)), 8vh, calc(var(--space) * 4 + env(safe-area-inset-top)));
+      padding-bottom:clamp(calc(var(--space) * 2 + constant(safe-area-inset-bottom)), 6vh, calc(var(--space) * 3.5 + constant(safe-area-inset-bottom)));
+      padding-bottom:clamp(calc(var(--space) * 2 + env(safe-area-inset-bottom)), 6vh, calc(var(--space) * 3.5 + env(safe-area-inset-bottom)));
       overflow-y:auto;
       background: radial-gradient(1200px 600px at 80% -10%, rgba(138,156,163,0.22), transparent 60%), radial-gradient(900px 500px at -10% 10%, rgba(0,58,95,0.25), transparent 60%), rgba(11,18,32,0.92);
       backdrop-filter: blur(8px);


### PR DESCRIPTION
## Summary
- increase the vertical padding of the login overlay using clamp-based spacing
- keep safe-area support while giving the card more room from the top edge

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb2308760832c89b013c39565117c