### PR TITLE
Fix board rendering error

### DIFF
--- a/index.html
+++ b/index.html
@@ -9256,7 +9256,6 @@
         ${phonePill}
         ${mailPill}
       </div>
-      ${detailsFooter}
     `;
     d.addEventListener('click', ()=>openDetails(r));
     d.addEventListener('keypress',e=>{ if(e.key==="Enter") openDetails(r) });


### PR DESCRIPTION
## Summary
- remove the undefined `detailsFooter` placeholder from lead cards so the board can render without throwing a runtime error

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb2e440cc832c927655b229348cb3