### PR TITLE
Refina el estilo de los filtros en el panel de control

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,16 +75,18 @@
     html[data-theme="light"] .nav-footer__meta{ border-color:rgba(15,23,42,0.08); color:#475569; }
     html[data-theme="light"] .nav-footer__rights{ color:#475569; }
     html[data-theme="light"] .view-controls .filters label{
-      background: rgba(var(--panel-base-rgb),0.12);
-      border-color: rgba(var(--panel-base-rgb),0.28);
-      color: #0f172a;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 10px 24px rgba(var(--panel-base-rgb),0.16);
+      background: linear-gradient(155deg, color-mix(in srgb, #ffffff 86%, rgba(var(--panel-base-rgb),0.12) 14%), color-mix(in srgb, rgba(var(--panel-base-rgb),0.22) 48%, #f1f5ff 52%));
+      border-color: color-mix(in srgb, rgba(var(--panel-base-rgb),0.42) 70%, transparent 30%);
+      color: color-mix(in srgb, #0f172a 88%, rgba(var(--panel-base-rgb),0.32) 12%);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.8), 0 18px 42px color-mix(in srgb, rgba(var(--panel-base-rgb),0.2) 32%, rgba(15,23,42,0.08));
+      backdrop-filter: blur(16px);
     }
     html[data-theme="light"] .view-controls .filters label select{
-      background: rgba(255,255,255,0.92);
-      border-color: rgba(var(--panel-base-rgb),0.3);
-      color:#0f172a;
-      box-shadow: inset 0 1px 2px rgba(var(--panel-base-rgb),0.18);
+      background-color: color-mix(in srgb, #ffffff 92%, rgba(var(--panel-base-rgb),0.1) 8%);
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%23264963' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+      border-color: color-mix(in srgb, rgba(var(--panel-base-rgb),0.45) 68%, rgba(15,23,42,0.1) 32%);
+      color: color-mix(in srgb, #0f172a 90%, rgba(var(--panel-base-rgb),0.28) 10%);
+      box-shadow: inset 0 1px 2px color-mix(in srgb, rgba(var(--panel-base-rgb),0.24) 40%, rgba(15,23,42,0.12));
     }
     html[data-theme="light"] .view-controls .filters label select.is-multiple{
       background:#ffffff;
@@ -803,39 +805,49 @@
       flex:1 1 auto;
     }
     .view-controls .filters label {
+      position:relative;
       display:flex;
       flex-direction:column;
-      gap:6px;
+      gap:8px;
       font-size:13px;
       font-weight:600;
-      color: rgba(248,252,255,0.92);
+      color: color-mix(in srgb, #ffffff 92%, rgba(var(--panel-base-rgb),0.22) 8%);
       flex:1 1 160px;
       min-width:160px;
-      padding:12px;
-      background: rgba(var(--panel-base-rgb),0.18);
-      border:1px solid rgba(var(--panel-base-rgb),0.35);
-      border-radius:14px;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 12px 28px rgba(2,10,28,0.28);
-      transition: border-color .2s ease, box-shadow .2s ease;
+      padding:14px 16px;
+      background: linear-gradient(160deg, rgba(var(--panel-base-rgb),0.28), rgba(8,19,45,0.68));
+      border:1px solid rgba(var(--panel-base-rgb),0.45);
+      border-radius:18px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 18px 38px rgba(2,10,28,0.34);
+      backdrop-filter: blur(18px);
+      transition: border-color .25s ease, box-shadow .25s ease, transform .25s ease;
     }
     .view-controls .filters label:hover,
     .view-controls .filters label:focus-within {
-      border-color: rgba(148,193,255,0.6);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 16px 32px rgba(2,10,28,0.35);
+      border-color: rgba(148,193,255,0.85);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.16), 0 22px 46px rgba(2,10,28,0.42);
+      transform: translateY(-2px);
     }
     .view-controls .filters label select {
       min-width:160px;
       width:100%;
-      padding:10px 12px;
-      border-radius:10px;
-      border:1px solid rgba(148,193,255,0.4);
-      background: rgba(8,19,45,0.55);
-      color:#f8fbff;
-      box-shadow: inset 0 1px 2px rgba(15,23,42,0.65);
+      padding:12px 42px 12px 14px;
+      border-radius:12px;
+      border:1px solid rgba(148,193,255,0.55);
+      background-color: color-mix(in srgb, rgba(8,19,45,0.82) 85%, rgba(12,23,42,0.45) 15%);
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%23bcd4ff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m6 8 4 4 4-4'/%3E%3C/svg%3E");
+      background-repeat:no-repeat;
+      background-position:right 16px center;
+      background-size:14px;
+      color:#f4f8ff;
+      box-shadow: inset 0 1px 3px rgba(5,12,28,0.65);
+      transition: border-color .2s ease, box-shadow .2s ease, background-color .2s ease, transform .2s ease;
+      appearance:none;
     }
     .view-controls .filters label select.is-multiple{
       min-height:140px;
-      padding-right:8px;
+      padding:10px 12px;
+      background-image:none;
       overflow:auto;
     }
     .view-controls .filters label select.is-multiple option{
@@ -845,8 +857,9 @@
     }
     .view-controls .filters label select:focus {
       outline:none;
-      border-color: rgba(148,193,255,0.75);
-      box-shadow: inset 0 1px 2px rgba(15,23,42,0.75), 0 0 0 3px rgba(var(--panel-base-rgb),0.35);
+      border-color: rgba(148,193,255,0.9);
+      background-color: color-mix(in srgb, rgba(8,19,45,0.82) 70%, rgba(28,46,84,0.75) 30%);
+      box-shadow: inset 0 1px 3px rgba(2,10,28,0.78), 0 0 0 3px rgba(var(--panel-base-rgb),0.35);
     }
     .view-controls .filters .page-size {
       margin-left:auto;


### PR DESCRIPTION
## Summary
- realza las tarjetas de filtros con gradientes, blur y sombras suaves en ambos temas para una apariencia más moderna
- mejora los controles select con rellenos equilibrados, ícono de desplegable personalizado y estados de foco más claros

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb3c34f38832c89bba60eab6ab300