### PR TITLE
Add JSON headers to authentication requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -15796,6 +15796,9 @@
       try{
         const response = await fetch(API_URL, {
           method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify({ action: 'requestPasswordReset', email, userId })
         });
         let data = null;
@@ -15844,6 +15847,9 @@
       try{
         const response = await fetch(API_URL, {
           method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify({ action: 'login', email, password })
         });
         let data = null;


### PR DESCRIPTION
## Summary
- ensure the password reset and login forms send JSON payloads with the appropriate Content-Type header
- avoid Apps Script rejecting authentication calls due to missing action in the parsed request body

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdbf5018a8832cb9a2ec4dd8b74e45