### PR TITLE
Fix view section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2407,7 +2407,7 @@
               </div>
             </div>
             <p class="contact-scripts__status hidden" id="contactScriptStatus" role="status" aria-live="polite"></p>
-          </div>
+          </section>
           <div class="actions" style="margin-top:10px">
             <button class="btn primary" id="updateBtn">Guardar</button>
           </div>


### PR DESCRIPTION
## Summary
- close the `panel-quick` section in the lead detail panel so subsequent views stay inside the main layout
- ensure sidebar tabs show their content without extra blank space at the top

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb31ffd0c832c8b0e8ac21ab447bd