### PR TITLE
Fix login/reset requests to avoid CORS preflight

### DIFF
--- a/index.html
+++ b/index.html
@@ -16035,9 +16035,6 @@
       try{
         const response = await fetch(API_URL, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
           body: JSON.stringify({ action: 'requestPasswordReset', email, userId })
         });
         let data = null;
@@ -16094,9 +16091,6 @@
       try{
         const response = await fetch(API_URL, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
           body: JSON.stringify({ action: 'login', email, password })
         });
         let data = null;


### PR DESCRIPTION
## Summary
- avoid forcing application/json header on login and password reset requests to prevent failing CORS preflight
- let Apps Script receive the JSON payload exactly as expected so login and reset flows complete again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdd0567320832cafaad5f3abd0c8f1