### PR TITLE
Fix lead loading from Apps Script

### DIFF
--- a/index.html
+++ b/index.html
@@ -8439,28 +8439,26 @@
       return;
     }
     try{
+      let loadedLeads = [];
       if(state.sheet === ALL_SHEETS_VALUE){
         const sheetNames = sheets.filter(Boolean);
-        const results = [];
         for(const sheetName of sheetNames){
           try{
             const list = await fetchLeadsForSheet(sheetName);
-            results.push(...list);
+            if(Array.isArray(list) && list.length){
+              loadedLeads.push(...list);
+            }
           }catch(err){
             if(err && err.code === 'UNAUTHORIZED') throw err;
           }
         }
-        leads = mapped;
-        autoReassignmentPlan = buildAutoReassignmentPlan(leads);
-        applyAutoReassignmentAnnotations();
-        state.columnLimits = {};
-        state.columnLimitSignature = '';
-      }else if(data && data.error){
-        throw new Error(data.error);
       }else{
-        leads = [];
-        syncQuickAccessWithLeads();
+        loadedLeads = await fetchLeadsForSheet(state.sheet);
       }
+      leads = Array.isArray(loadedLeads) ? loadedLeads : [];
+      autoReassignmentPlan = buildAutoReassignmentPlan(leads);
+      applyAutoReassignmentAnnotations();
+      syncQuickAccessWithLeads();
       state.columnLimits = {};
       state.columnLimitSignature = '';
     }catch(err){
@@ -8468,6 +8466,8 @@
       console.error('Error al cargar leads', err);
       leads = [];
       syncQuickAccessWithLeads();
+      state.columnLimits = {};
+      state.columnLimitSignature = '';
     }
   }
 


### PR DESCRIPTION
## Summary
- fix the loadLeads workflow so it stores the retrieved rows instead of referencing undefined variables
- ensure quick-access syncing and column limit state resets occur after successful fetches as well as failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee9275338832cb37d0899049f4495