### PR TITLE
Improve mobile layout and board colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
       --panel-base-soft: color-mix(in srgb, rgb(var(--panel-base-rgb)) 54%, #0b1220 46%);
       --panel-base-bright: color-mix(in srgb, rgb(var(--panel-base-rgb)) 68%, #f8fafc 32%);
       --panel-stage-text: #f8fafc;
-      --etapa-nuevo: #2563eb;
-      --etapa-contactado: #0ea5e9;
-      --etapa-no-contactado: #d97706;
-      --etapa-inscrito: #16a34a;
-      --etapa-descartado: #dc2626;
+      --etapa-nuevo: color-mix(in srgb, var(--accent) 90%, #0b1220 10%);
+      --etapa-contactado: color-mix(in srgb, #0ea5e9 70%, var(--accent) 30%);
+      --etapa-no-contactado: color-mix(in srgb, #f59e0b 60%, var(--accent) 40%);
+      --etapa-inscrito: color-mix(in srgb, #22c55e 70%, var(--accent) 30%);
+      --etapa-descartado: color-mix(in srgb, #f87171 68%, var(--accent) 32%);
       --radius: 14px;
       --shadow: 0 10px 30px rgba(2,10,28,0.45);
       --ring: 0 0 0 3px rgba(0,58,95,.35);
@@ -70,6 +70,11 @@
       --panel-base-soft: color-mix(in srgb, rgb(var(--panel-base-rgb)) 30%, #ffffff 70%);
       --panel-base-bright: color-mix(in srgb, rgb(var(--panel-base-rgb)) 42%, #ffffff 58%);
       --panel-stage-text: #0f172a;
+      --etapa-nuevo: color-mix(in srgb, var(--accent) 70%, #ffffff 30%);
+      --etapa-contactado: color-mix(in srgb, #38bdf8 56%, var(--accent) 44%);
+      --etapa-no-contactado: color-mix(in srgb, #f59e0b 52%, var(--accent) 48%);
+      --etapa-inscrito: color-mix(in srgb, #4ade80 58%, var(--accent) 42%);
+      --etapa-descartado: color-mix(in srgb, #fb7185 60%, var(--accent) 40%);
     }
     html[data-theme="light"] .nav-footer{ border-top:1px solid rgba(15,23,42,0.08); }
     html[data-theme="light"] .nav-footer__meta{ border-color:rgba(15,23,42,0.08); color:#475569; }
@@ -327,6 +332,48 @@
     }
     @media (prefers-reduced-motion: reduce){
       .hero-metrics__track{ animation:none; }
+    }
+    @media (max-width: 768px){
+      :root{
+        --font-size-base: 14px;
+        --space: 14px;
+        --space-sm: 10px;
+        --space-xs: 6px;
+        --radius: 12px;
+      }
+      body{ line-height:1.55; }
+      .landing-layout{ gap:calc(var(--space) * 1.25); }
+      .landing-hero{ padding:calc(var(--space) * 1.5); border-radius:26px; }
+      .hero-note{ font-size:14px; }
+      .hero-metrics{ margin-inline:-4px; }
+      .hero-metrics__viewport{ mask-image:none; overflow-x:auto; scrollbar-width:thin; padding-inline:4px; }
+      .hero-metrics__viewport::-webkit-scrollbar{ height:6px; }
+      .hero-metrics__viewport::-webkit-scrollbar-thumb{ background:rgba(148,163,184,0.45); border-radius:999px; }
+      .hero-metrics__track{ gap:var(--space-sm); animation-duration:38s; }
+      .hero-metric{ min-width:180px; scroll-snap-align:start; }
+      .login-screen{ padding-inline:max(var(--space), 6vw); }
+      .login-card{ max-width:420px; width:100%; margin-inline:auto; padding:calc(var(--space) * 1.3); }
+      .login-actions{ gap:var(--space-sm); }
+      .mobile-topbar{ padding-inline:var(--space); }
+      .topbar-inner{ padding-inline:var(--space); }
+    }
+    @media (max-width: 540px){
+      .landing-hero{ padding:calc(var(--space) * 1.2); border-radius:22px; gap:var(--space-sm); }
+      .landing-hero h1{ font-size:clamp(26px, 8vw, 34px); }
+      .hero-subtitle{ font-size:15px; }
+      .hero-note{ font-size:13px; }
+      .hero-metrics__viewport{ scroll-snap-type:x mandatory; }
+      .hero-metrics__track{ width:max-content; }
+      .login-screen{ padding-inline:var(--space); padding-block:calc(var(--space) * 2.2); }
+      .login-card{ padding:var(--space); gap:var(--space-sm); }
+      .login-intro{ font-size:13px; }
+      .login-meta{ margin-top:var(--space); }
+      .login-actions .btn.primary{ font-size:1rem; padding:12px 16px; }
+      .mobile-topbar__label{ font-size:13px; letter-spacing:.4px; }
+      .view-section > .card,
+      .main .card{ margin:var(--space) !important; }
+      .kpi-group{ padding:calc(var(--space) * 0.85); }
+      .kpi-metric{ min-height:0; }
     }
     @media (max-width: 900px){
       .landing-layout{ grid-template-columns:1fr; }
@@ -1012,13 +1059,13 @@
     .content { display:flex; flex-direction:column; gap:var(--space-sm); }
     .board {
       display:grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap:8px;
-      padding:6px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap:var(--space-sm);
+      padding:var(--space-sm);
       background: var(--card);
       border:1px solid rgba(255,255,255,.08);
       border-radius:16px;
-      max-height: clamp(300px, 62vh, 420px);
+      max-height: clamp(320px, 65vh, 460px);
       overflow-y:auto;
       overflow-x:hidden;
       width:min(100%, calc(100vw - var(--sidebar-width, 0px) - (var(--space) * 2)));
@@ -1026,11 +1073,11 @@
       min-height:0;
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
     }
-    html[data-board-density="compact"] .board{ grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
-    html[data-board-density="expanded"] .board{ grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
-    .column { background: var(--card); border:1px solid rgba(255,255,255,.08); border-radius: 16px; min-height: 140px; display:flex; flex-direction:column }
-    .column header { display:flex; align-items:center; justify-content:space-between; padding:6px 8px; border-bottom:1px dashed rgba(255,255,255,.08) }
-    .column header .count { background: rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); padding:2px 6px; border-radius:999px; font-size:12px }
+    html[data-board-density="compact"] .board{ grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+    html[data-board-density="expanded"] .board{ grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+    .column { background: var(--card); border:1px solid rgba(255,255,255,.08); border-radius: 16px; min-height: 140px; display:flex; flex-direction:column; position:relative; overflow:hidden }
+    .column header { display:flex; align-items:center; justify-content:space-between; padding:10px 12px; border-bottom:1px solid rgba(255,255,255,.08); border-radius:14px 14px 0 0; gap:var(--space-xs); }
+    .column header .count { background: rgba(15,23,42,0.25); border:1px solid rgba(15,23,42,0.35); padding:2px 8px; border-radius:999px; font-size:12px; color:rgba(248,250,252,0.92); font-weight:600; }
     .column-toggle{ border:none; background:none; color:inherit; display:none; align-items:center; justify-content:center; padding:4px; border-radius:8px; cursor:pointer; }
     .column-toggle:focus-visible{ outline:none; box-shadow: var(--ring); }
     .column-toggle-icon{ transition: transform .2s ease; }
@@ -1038,6 +1085,12 @@
     .column-load-more{ margin:8px; padding:6px 10px; border-radius:10px; border:1px solid rgba(255,255,255,0.18); background:rgba(var(--panel-base-rgb),0.12); color:var(--text); font-weight:600; cursor:pointer; transition: background .2s ease; align-self:center; }
     .column-load-more:hover{ background:rgba(var(--panel-base-rgb),0.2); }
     html[data-theme="light"] .column-load-more{ border-color:rgba(15,23,42,0.16); background:rgba(37,99,235,0.12); }
+    html[data-theme="light"] .board{ border-color:rgba(15,23,42,0.1); box-shadow: inset 0 1px 0 rgba(255,255,255,0.8); }
+    html[data-theme="light"] .column{ border-color:rgba(15,23,42,0.1); }
+    html[data-theme="light"] .column header{ border-bottom-color:rgba(15,23,42,0.14); box-shadow: inset 0 -1px 0 rgba(255,255,255,0.6); }
+    html[data-theme="light"] .column header .count{ background:rgba(255,255,255,0.9); border-color:rgba(15,23,42,0.16); color:rgba(15,23,42,0.82); }
+    html[data-theme="light"] .column[data-step] header{ color:color-mix(in srgb, #0f172a 88%, rgba(255,255,255,0.2) 12%); box-shadow:0 14px 34px color-mix(in srgb, var(--etapa-color) 26%, rgba(15,23,42,0.18)); }
+    html[data-theme="light"] .column[data-step] header .count{ background:color-mix(in srgb, rgba(255,255,255,0.9) 78%, transparent 22%); border-color:color-mix(in srgb, rgba(15,23,42,0.18) 62%, transparent 38%); color:color-mix(in srgb, #0f172a 78%, var(--etapa-color) 22%); }
     html[data-board-density="compact"] .list{ gap:4px; }
     html[data-board-density="expanded"] .list{ gap:10px; }
     .card-lead { background: var(--card-2); border:1px solid rgba(255,255,255,.1); border-radius:14px; padding:8px; cursor:pointer; transition: transform .12s ease, box-shadow .12s ease; box-shadow: 0 1px 4px rgba(0,0,0,.06) }
@@ -1052,12 +1105,24 @@
     .tag.bad{ color: #7f1d1d; background: rgba(239,68,68,.15); border-color: rgba(239,68,68,.25) }
 
     /* Etapa colors */
-    .column[data-step="Nuevo"] header{ background: var(--etapa-nuevo); color:#fff; }
-    .column[data-step="Contactado"] header{ background: var(--etapa-contactado); color:#fff; }
-    .column[data-step="No Contactado"] header{ background: var(--etapa-no-contactado); color:#fff; }
-    .column[data-step="Inscrito"] header{ background: var(--etapa-inscrito); color:#fff; }
-    .column[data-step="Descartado"] header{ background: var(--etapa-descartado); color:#fff; }
-    .column[data-step] header .muted{ color: rgba(255,255,255,.75); }
+    .column[data-step]{ --etapa-color: var(--accent); }
+    .column[data-step] header{
+      background: linear-gradient(145deg, color-mix(in srgb, var(--etapa-color) 82%, rgba(15,23,42,0.2) 18%), color-mix(in srgb, var(--etapa-color) 62%, rgba(5,12,28,0.4) 38%));
+      color:color-mix(in srgb, #f8fafc 92%, rgba(148,163,184,0.18) 8%);
+      border-bottom:none;
+      box-shadow:0 12px 32px color-mix(in srgb, var(--etapa-color) 32%, rgba(5,12,28,0.45));
+    }
+    .column[data-step] header .count{
+      background:color-mix(in srgb, rgba(15,23,42,0.35) 60%, rgba(255,255,255,0.12) 40%);
+      border-color:color-mix(in srgb, rgba(15,23,42,0.45) 65%, transparent 35%);
+      color:inherit;
+    }
+    .column[data-step] header .muted{ color:color-mix(in srgb, currentColor 78%, rgba(15,23,42,0.2) 22%); }
+    .column[data-step="Nuevo"]{ --etapa-color: var(--etapa-nuevo); }
+    .column[data-step="Contactado"]{ --etapa-color: var(--etapa-contactado); }
+    .column[data-step="No Contactado"]{ --etapa-color: var(--etapa-no-contactado); }
+    .column[data-step="Inscrito"]{ --etapa-color: var(--etapa-inscrito); }
+    .column[data-step="Descartado"]{ --etapa-color: var(--etapa-descartado); }
 
     .panel[data-etapa]{
       background: linear-gradient(150deg, var(--panel-tone-strong), var(--panel-tone-soft));
@@ -1938,7 +2003,8 @@
     }
     @media (max-width: 700px){
       .kpi-grid{ grid-template-columns: repeat(auto-fit, minmax(180px,1fr)); }
-      .board{ grid-template-columns: repeat(3,minmax(180px,1fr)) }
+      .board{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space-sm); max-height:none; overflow:visible; }
+      .column{ min-height:0; }
       .view-controls{
         flex-direction:column;
         align-items:flex-start;
@@ -1948,13 +2014,14 @@
       .view-controls .filters{
         width:100%;
         display:flex;
-        gap:var(--space-sm);
-        flex-wrap:nowrap;
-        align-items:flex-end;
+        gap:var(--space-xs);
+        row-gap:var(--space-sm);
+        flex-wrap:wrap;
+        align-items:flex-start;
       }
       .view-controls .filters label{
         width:100%;
-        flex:1 1 0;
+        flex:1 1 calc(50% - var(--space-xs));
         min-width:0;
       }
       .view-controls .filters label select{
@@ -1963,7 +2030,7 @@
       }
       .view-controls .filters .page-size{
         margin-left:0;
-        flex:1 1 0;
+        flex:1 1 100%;
       }
       .column.mobile-collapsible{ min-height:0; }
       .column.mobile-collapsible header{ padding:10px 12px; }
@@ -1975,9 +2042,8 @@
     }
     @media (max-width: 600px){
       .kpi-grid{ grid-template-columns:1fr; }
-      .board{ grid-template-columns: repeat(2,minmax(180px,1fr)) }
-      .view-controls .filters{ gap:8px; }
-      .view-controls .filters label{ flex:1 1 0; }
+      .view-controls .filters{ gap:var(--space-xs); }
+      .view-controls .filters label{ flex:1 1 100%; }
       .view-controls .filters label select{ padding:6px 10px; font-size:13px; }
     }
     @media (max-width: 480px){
@@ -1990,10 +2056,15 @@
       .actions .btn{ padding:8px 12px; }
       #themeBtn{ top:12px; right:12px }
       .view-controls .filters{ gap:6px; }
-      .view-controls .filters label{ flex:1 1 0; font-size:12px; }
+      .view-controls .filters label{ flex:1 1 100%; font-size:12px; }
       .view-controls .filters label select{ padding:6px 8px; font-size:12px; }
     }
-    @media (max-width: 400px){ .board{ grid-template-columns: repeat(1,minmax(180px,1fr)) } }
+    @media (max-width: 420px){
+      .hero-metrics__viewport{ padding-inline:0; }
+      .hero-metric{ min-width:160px; }
+      .board{ padding:var(--space-xs); }
+      .column header{ padding:10px; }
+    }
 
     /* Help view */
     .help-role{ display:flex; flex-direction:column; gap:var(--space-sm); padding:var(--space); border-radius:var(--radius); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); }


### PR DESCRIPTION
## Summary
- harmonize the board stage palette with the primary color scheme and refresh column header styling
- refine board layout spacing and light theme treatments while keeping columns readable on mobile
- add responsive tweaks for hero metrics, login, filters, and cards to improve the mobile experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1d1b97b4832cb7507a7b650f9b7d