### PR TITLE
Update default API URL to new Apps Script endpoint

### DIFF
--- a/config/app-config.js
+++ b/config/app-config.js
@@ -8,7 +8,7 @@
   const config = {
     API_URL:
       source.API_URL ||
-      'https://script.google.com/macros/s/AKfycbxAbz6lojrPvMqhLkBlrDE16jQpq3G8ix6ox8c9zDKYnmaTtn9MXCWDBwOlJ_0lVQlp/exec',
+      'https://script.googleapis.com/v1/scripts/AKfycbwqo6LZiSIwNE-SF4uMA2vzJ2Ej-qhUBw9GT0cf3R-ABwBcYTODOlPhuARygYF-BPWU0Q:run',
     REQUEST_TIMEOUT_MS: Number.isFinite(source.REQUEST_TIMEOUT_MS)
       ? source.REQUEST_TIMEOUT_MS
       : 45000,

--- a/index.html
+++ b/index.html
@@ -3964,7 +3964,7 @@
   <script>
   // —— Datos desde Google Sheets ——
   const appConfig = window.ReLeadConfig || {};
-  const API_URL = appConfig.API_URL || 'https://script.google.com/macros/s/AKfycbxAbz6lojrPvMqhLkBlrDE16jQpq3G8ix6ox8c9zDKYnmaTtn9MXCWDBwOlJ_0lVQlp/exec';
+  const API_URL = appConfig.API_URL || 'https://script.googleapis.com/v1/scripts/AKfycbwqo6LZiSIwNE-SF4uMA2vzJ2Ej-qhUBw9GT0cf3R-ABwBcYTODOlPhuARygYF-BPWU0Q:run';
   const REQUEST_TIMEOUT_MS = Number.isFinite(appConfig.REQUEST_TIMEOUT_MS) ? appConfig.REQUEST_TIMEOUT_MS : 45000;
   const SESSION_HEARTBEAT_INTERVAL_MS = Number.isFinite(appConfig.SESSION_HEARTBEAT_INTERVAL_MS)
     ? Math.max(60000, appConfig.SESSION_HEARTBEAT_INTERVAL_MS)


### PR DESCRIPTION
## Summary
- update the default API_URL configuration to the new Google Apps Script execution endpoint
- mirror the same endpoint change in the inlined configuration within index.html

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf35292eac832c8bc9c3512f1d8b57