### PR TITLE
Update default API URL

### DIFF
--- a/config/app-config.js
+++ b/config/app-config.js
@@ -8,7 +8,7 @@
   const config = {
     API_URL:
       source.API_URL ||
-      'https://script.googleapis.com/v1/scripts/AKfycbwqo6LZiSIwNE-SF4uMA2vzJ2Ej-qhUBw9GT0cf3R-ABwBcYTODOlPhuARygYF-BPWU0Q:run',
+      'https://script.google.com/macros/s/AKfycbzUlmaB2fxgViF3EnU2t315CRohSsNu3ZxKtkDhgjLMhQJxavg1pWlEG7_VGmyx3nI/exec',
     REQUEST_TIMEOUT_MS: Number.isFinite(source.REQUEST_TIMEOUT_MS)
       ? source.REQUEST_TIMEOUT_MS
       : 45000,

--- a/index.html
+++ b/index.html
@@ -4035,7 +4035,7 @@
   <script>
   // —— Datos desde Google Sheets ——
   const appConfig = window.ReLeadConfig || {};
-  const API_URL = appConfig.API_URL || 'https://script.googleapis.com/v1/scripts/AKfycbwqo6LZiSIwNE-SF4uMA2vzJ2Ej-qhUBw9GT0cf3R-ABwBcYTODOlPhuARygYF-BPWU0Q:run';
+  const API_URL = appConfig.API_URL || 'https://script.google.com/macros/s/AKfycbzUlmaB2fxgViF3EnU2t315CRohSsNu3ZxKtkDhgjLMhQJxavg1pWlEG7_VGmyx3nI/exec';
   const REQUEST_TIMEOUT_MS = Number.isFinite(appConfig.REQUEST_TIMEOUT_MS) ? appConfig.REQUEST_TIMEOUT_MS : 45000;
   const SESSION_HEARTBEAT_INTERVAL_MS = Number.isFinite(appConfig.SESSION_HEARTBEAT_INTERVAL_MS)
     ? Math.max(60000, appConfig.SESSION_HEARTBEAT_INTERVAL_MS)


### PR DESCRIPTION
## Summary
- replace the default Apps Script API endpoint with the latest provided macro URL in both the config module and HTML bootstrap fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf393cb51c832c9ee025304129b233